### PR TITLE
give read permission to /etc/apt/sources.list.d/newrelic.list

### DIFF
--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -32,7 +32,7 @@ case node[:platform]
 			source "http://download.newrelic.com/debian/newrelic.list"
 			owner "root"
 			group "root"
-			mode 0640
+			mode 0644
 			notifies :run, "execute[newrelic-apt-get-update]", :immediately
 			action :create_if_missing
 		end


### PR DESCRIPTION
Everyone should be able to read /etc/apt/sources.list.d/*.list files.

This fixes this annoying message:

```
$ aptitude search something
E: Opening /etc/apt/sources.list.d/newrelic.list - ifstream::ifstream (13: Permission denied)
E: Opening /etc/apt/sources.list.d/newrelic.list - ifstream::ifstream (13: Permission denied)
E: The list of sources could not be read.
```
