### PR TITLE
Fixed missing license_key from newrelic.python.erb

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ References
 
 CHANGELOG :
 ===========
+### 0.3.5
+    * Fixed missing license_key from newrelic.python.erb
 ### 0.3.4
     * New python agent installation (Paul Rossman)
     * New newrelic.python.erb

--- a/recipes/python-agent.rb
+++ b/recipes/python-agent.rb
@@ -19,6 +19,7 @@ template "/etc/newrelic/newrelic.ini" do
 	group "root"
 	mode "0644"
 	variables(
+        :license_key => node[:newrelic][:license_key],
 		:app_name => node[:newrelic][:app_name]
 	)
 	action :create


### PR DESCRIPTION
Hi David,

The all important license_key was missing from newrelic.python.erb. I also incremented the version # in the readme, but I noticed that metadata version # is at 0.3.5. Please update as you see necessary.

Cheers!
Paul
