### PR TITLE
Added attribute to specify python version

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Attributes
 * `node['newrelic']['repository_key']` - The New Relic repository key, defaults to "548C16BF"
 * `node['newrelic']['license_key']` - Your New Relic license key.
 * `node['newrelic']['app_name']` - Your New Relic application name. (python agent only)
+* `node['newrelic']['python_version']` - Defaults to "latest". Version numbers can be found at http://download.newrelic.com/python_agent/release/ (python agent only)
 
 Usage
 =====
@@ -68,6 +69,9 @@ References
 
 Changelog
 =========
+
+### 0.3.6
+    * Added attribute to specify python version. Versions can be found at http://download.newrelic.com/python_agent/release/
 
 ### 0.3.5
 	* Fixed missing license_key from newrelic.python.erb

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -8,3 +8,4 @@
 default['newrelic']['repository_key'] = "548C16BF"
 default['newrelic']['license_key'] = "CHANGE_ME"
 default['newrelic']['app_name'] = "CHANGE_ME"
+default['newrelic']['python_version'] = "latest"

--- a/recipes/python-agent.rb
+++ b/recipes/python-agent.rb
@@ -10,6 +10,9 @@ include_recipe "python::pip"
 # install latest python agent
 python_pip "newrelic" do
   action :install
+  if node[:newrelic][:python_version] != "latest"
+    version "#{node[:newrelic][:python_version]}"
+  end
 end
 
 #configure your New Relic license key


### PR DESCRIPTION
There are occasional exceptions were we needed to specify a python agent version. Versions can be found at http://download.newrelic.com/python_agent/release/
