### PR TITLE
Use a template to configure the server-monitor instead of the non-idempotent execute

### DIFF
--- a/recipes/server-monitor.rb
+++ b/recipes/server-monitor.rb
@@ -11,9 +11,15 @@ package "newrelic-sysmond" do
 end
 
 #configure your New Relic license key
-execute "newrelic-nrsysmond-config" do
-	command "nrsysmond-config --set license_key=#{node[:newrelic][:license_key]}"
-	action :run
+template "/etc/newrelic/nrsysmond.cfg" do
+	source "nrsysmond.cfg.erb"
+	owner "root"
+	group "newrelic"
+	mode "640"
+	variables(
+		:license_key => node[:newrelic][:license_key]
+	)
+	notifies :restart, "service[newrelic-sysmond]"
 end
 
 service "newrelic-sysmond" do

--- a/templates/default/nrsysmond.cfg.erb
+++ b/templates/default/nrsysmond.cfg.erb
@@ -1,0 +1,158 @@
+#
+# New Relic Server Monitor configuration file.
+#
+# Lines that begin with a # are comment lines and are ignored by the server
+# monitor. For those options that have command line equivalents, if the
+# option is specified on the command line it will over-ride any value set
+# in this file.
+#
+
+#
+# Option : license_key
+# Value  : 40-character hexadecimal string provided by New Relic. This is
+#          required in order for the server monitor to start.
+# Default: none
+#
+license_key=<%= @license_key %>
+
+#
+# Option : loglevel
+# Value  : Level of detail you want in the log file (as defined by the logfile
+#          setting below. Valid values are (in increasing levels of verbosity):
+#          error        - show errors only
+#          warning      - show errors and warnings
+#          info         - show minimal additional information messages
+#          verbose      - show more detailed information messages
+#          debug        - show debug messages
+#          verbosedebug - show very detailed debug messages
+# Default: error
+# Note   : Can also be set with the -d command line option.
+#
+loglevel=info
+
+#
+# Option : logfile
+# Value  : Name of the file where the server monitor will store it's log
+#          messages. The amount of detail stored in this file is controlled
+#          by the loglevel option (above).
+# Default: none. However it is highly recommended you set a value for this.
+# Note   : Can also be set with the -l command line option.
+#
+logfile=/var/log/newrelic/nrsysmond.log
+
+#
+# Option : proxy
+# Value  : The name and optional login credentials of the proxy server to use
+#          for all communication with the New Relic collector. In its simplest
+#          form this setting is just a hostname[:port] setting. The default
+#          port if none is specified is 1080. If your proxy requires a user
+#          name, use the syntax user@host[:port]. If it also requires a
+#          password use the format user:password@host[:port]. For example:
+#            fred:secret@proxy.mydomain.com:8181
+# Default: none (use a direct connection)
+#
+#proxy=
+
+#
+# Option : ssl
+# Value  : Whether or not to use the Secure Sockets Layer (SSL) for all
+#          communication with the New Relic collector. Possible values are
+#          true/on or false/off. In certain rare cases you may need to modify
+#          the SSL certificates settings below.
+# Default: false
+#
+#ssl=false
+
+#
+# Option : ssl_ca_bundle
+# Value  : The name of a PEM-encoded Certificate Authority (CA) bundle to use
+#          for SSL connections. This very rarely needs to be set. The monitor
+#          will attempt to find the bundle in the most common locations. If
+#          you need to use SSL and the monitor is unable to locate a CA bundle
+#          then either set this value or the ssl_ca_path option below.
+# Default: /etc/ssl/certs/ca-certificates.crt or
+#          /etc/pki/tls/certs/ca-bundle.crt
+# Note   : Can also be set with the -b command line option.
+#
+#ssl_ca_bundle=/path/to/your/bundle.crt
+
+#
+# Option : ssl_ca_path
+# Value  : If your SSL installation does not use CA bundles, but rather has a
+#          directory with PEM-encoded Certificate Authority files, set this
+#          option to the name of the directory that contains all the CA files.
+# Default: /etc/ssl/certs
+# Note   : Can also be set with the -S command line option.
+#
+#ssl_ca_path=/etc/ssl/certs
+
+#
+# Option : pidfile
+# Value  : Name of a file where the server monitoring daemon will store it's
+#          process ID (PID). This is used by the startup and shutdown script
+#          to determine if the monitor is already running, and to start it up
+#          or shut it down.
+# Default: /tmp/nrsysmond.pid
+# Note   : Can also be set with the -p command line option.
+#
+#pidfile=/var/run/newrelic/nrsysmond.pid
+
+#
+# Option : collector_host
+# Value  : The name of the New Relic collector to connect to. This should only
+#          ever be changed on advise from a New Relic support staff member.
+#          The format is host[:port]. Using a port number of 0 means the default
+#          port, which is 80 (if not using the ssl option - see below) or 443
+#          if SSL is enabled. If the port is omitted the default value is used.
+#          then either set this value or the ssl_ca_path option below.
+# Default: /etc/ssl/certs/ca-certificates.crt or
+#          /etc/pki/tls/certs/ca-bundle.crt
+# Note   : Can also be set with the -b command line option.
+#
+#ssl_ca_bundle=/path/to/your/bundle.crt
+
+#
+# Option : ssl_ca_path
+# Value  : If your SSL installation does not use CA bundles, but rather has a
+#          directory with PEM-encoded Certificate Authority files, set this
+#          option to the name of the directory that contains all the CA files.
+# Default: /etc/ssl/certs
+# Note   : Can also be set with the -S command line option.
+#
+#ssl_ca_path=/etc/ssl/certs
+
+#
+# Option : pidfile
+# Value  : Name of a file where the server monitoring daemon will store it's
+#          process ID (PID). This is used by the startup and shutdown script
+#          to determine if the monitor is already running, and to start it up
+#          or shut it down.
+# Default: /tmp/nrsysmond.pid
+# Note   : Can also be set with the -p command line option.
+#
+#pidfile=/var/run/newrelic/nrsysmond.pid
+
+#
+# Option : collector_host
+# Value  : The name of the New Relic collector to connect to. This should only
+#          ever be changed on advise from a New Relic support staff member.
+#          The format is host[:port]. Using a port number of 0 means the default
+#          port, which is 80 (if not using the ssl option - see below) or 443
+#          if SSL is enabled. If the port is omitted the default value is used.
+# Default: collector.newrelic.com
+#
+#collector_host=collector.newrelic.com
+
+#
+# Option : timeout
+# Value  : How long the monitor should wait to contact the collector host. If
+#          the connection cannot be established in this period of time, the
+#          monitor will progressively back off in 15-second increments, up to
+#          a maximum of 300 seconds. Once the initial connection has been
+#          established, this value is reset back to the value specified here
+#          (or the default). This then sets the maximum time to wait for
+#          a connection to the collector to report data. There is no back-off
+#          once the original connection has been made. The value is in seconds.
+# Default: 30
+#
+#timeout=30


### PR DESCRIPTION
By executing newrelic-nrsysmond-config every time Chef ran, that meant the file was recreated on our systems every 30 minutes and that was driving our file modification monitoring that we need for PCI a little crazy. With a template, the file is only recreated if the license key changes, which will also restart the service. The other options could be exposed at attributes in the future.
