### PR TITLE
Remove apache2 dependency

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -12,6 +12,9 @@
 default['newrelic']['server_monitoring']['license'] = "CHANGE_ME"
 default['newrelic']['application_monitoring']['license'] = "CHANGE_ME"
 
+# Set the host service that needs to be restarted-- e.g. php5-fpm or apache2
+default['newrelic']['php_service'] = "php5-fpm"
+
 ################
 #ADVANCED CONFIG
 ################

--- a/recipes/php-agent.rb
+++ b/recipes/php-agent.rb
@@ -5,10 +5,8 @@
 # Copyright 2012, Escape Studios
 #
 
-# Execute apache2 receipe + mod_php5 receipe
+# Execute apache2 receipe + mod_php5 recipe
 include_recipe "php"
-include_recipe "apache2"
-include_recipe "apache2::mod_php5"
 
 #the older version (3.0) had a bug in the init scripts that when it shut down the daemon it would also kill dpkg as it was trying to upgrade
 #let's remove the old packages before continuing
@@ -26,12 +24,12 @@ end
 execute "newrelic-install" do
 	command "newrelic-install install"
 	action :run
-	notifies :restart, "service[apache2]", :delayed
+	notifies :restart, "service[#{node[:newrelic][:php_service]}]", :delayed
 end
 
 service "newrelic-daemon" do
   supports :status => true, :start => true, :stop => true, :restart => true
-  notifies :restart, "service[apache2]", :delayed
+	notifies :restart, "service[#{node[:newrelic][:php_service]}]", :delayed
 end
 
 #https://newrelic.com/docs/php/newrelic-daemon-startup-modes
@@ -102,7 +100,7 @@ if node[:newrelic][:startup_mode] == "agent"
 			:webtransaction_name_files => node[:newrelic][:application_monitoring][:webtransaction][:name][:files]
 		)
 		action :create
-		notifies :restart, "service[apache2]", :delayed
+	notifies :restart, "service[#{node[:newrelic][:php_service]}]", :delayed
 	end
 else
 	#external startup mode


### PR DESCRIPTION
This cookbook assumes mod_php, but doesn't work for php-fpm model of serving PHP. Added an attribute to allow the user to override what service needs to be restarted to pull in the nginx settings.

Would love to get this pushed into the next release of this module.

Thanks.
