### PR TITLE
Refactoring for style

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,12 @@ Attributes
 ## default.rb:
 
 ### BASIC
-* `node['newrelic']['server_monitoring']['license']` - Your New Relic license key for server monitoring purposes (usually same license key as application monitoring license)
-* `node['newrelic']['application_monitoring']['license']` - Your New Relic license key for server monitoring purposes (usually same license key as server monitoring license)
+* `node['newrelic']['license_key']` - Your New Relic license key. This is usually the same for server and application monitoring, if required you can assign discrete keys using advanced attributes detailed below.
+
 
 ### ADVANCED
+* `node['newrelic']['server_monitoring']['license']`
+* `node['newrelic']['application_monitoring']['license']`
 * `node['newrelic']['server_monitoring']['logfile']`
 * `node['newrelic']['server_monitoring']['loglevel']`
 * `node['newrelic']['server_monitoring']['proxy']`
@@ -96,34 +98,43 @@ Usage
 =====
 
 1)
-include `recipe[newrelic]` in a run list to implicly run `recipe[newrelic::install]` and `recipe[newrelic::server-monitor]`
-- OR -
+include `recipe[newrelic]` in a run list to implicly run `recipe[newrelic::install]` and `recipe[newrelic::server-monitor]`  
+--- OR ---  
 include the bits and pieces explicitly in a run list:
-`recipe[newrelic::install]`
-`recipe[newrelic::server-monitor]`
-`recipe[newrelic::php-agent]`
-`recipe[newrelic::python-agent]`
+
+```ruby
+recipe[newrelic::install]  
+recipe[newrelic::server-monitor]  
+recipe[newrelic::php-agent]  
+recipe[newrelic::python-agent]  
+```
 
 2)
-	change the `node['newrelic']['license_key']` attribute to your New Relic license key
-	--- OR ---
-	override the attribute on a higher level (http://wiki.opscode.com/display/chef/Attributes#Attributes-AttributesPrecedence)
+change the `node['newrelic']['license_key']` attribute to your New Relic license key  
+--- OR ---  
+override the attribute on a higher level (http://wiki.opscode.com/display/chef/Attributes#Attributes-AttributesPrecedence)
 
 References
 ==========
 
-* [New Relic home page] (http://newrelic.com/)
-* [New Relic for Server Monitoring] (https://newrelic.com/docs/server/new-relic-for-server-monitoring)
-* [New Relic for PHP] (https://newrelic.com/docs/php/new-relic-for-php)
-* [newrelic-daemon startup modes] (https://newrelic.com/docs/php/newrelic-daemon-startup-modes)
-* [New Relic for Python] (https://newrelic.com/docs/python/new-relic-for-python)
-* ["newrelic" cookbook by heavywater on github] (https://github.com/heavywater/chef-newrelic)
-* ["newrelic_monitoring" cookbook on community.opscode.com] (http://community.opscode.com/cookbooks/newrelic_monitoring)
-* ["newrelic_monitoring" cookbook on github] (https://github.com/8thBridge/chef-newrelic-monitoring)
+* [New Relic home page](http://newrelic.com/)
+* [New Relic for Server Monitoring](https://newrelic.com/docs/server/new-relic-for-server-monitoring)
+* [New Relic for PHP](https://newrelic.com/docs/php/new-relic-for-php)
+* [newrelic-daemon startup modes](https://newrelic.com/docs/php/newrelic-daemon-startup-modes)
+* [New Relic for Python](https://newrelic.com/docs/python/new-relic-for-python)
+* ["newrelic" cookbook by heavywater on github](https://github.com/heavywater/chef-newrelic)
+* ["newrelic_monitoring" cookbook on community.opscode.com](http://community.opscode.com/cookbooks/newrelic_monitoring)
+* ["newrelic_monitoring" cookbook on github](https://github.com/8thBridge/chef-newrelic-monitoring)
 * a very big thanks to heavywater <darrin@heavywater.ca> for the original version of this cookbook
 
 Changelog
 =========
+
+### 0.4.8
+    * use apt_repository LWRP for installing on debian variants (Robert Coleman)
+    * refactor style for to pass foodcritic (Robert Coleman)
+    * add `license_key` meta attribute (Robert Coleman)
+    * case statement for php-agent startup mode (Robert Coleman)
 
 ### 0.4.7
     * splitting up attributes into recipe-specific files
@@ -163,7 +174,7 @@ Changelog
     * Added attribute to specify python version. Versions can be found at http://download.newrelic.com/python_agent/release/
 
 ### 0.3.5
-	* Fixed missing license_key from newrelic.python.erb
+    * Fixed missing license_key from newrelic.python.erb
     * Cleanup of README
 
 ### 0.3.4

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -9,8 +9,9 @@
 #BASIC CONFIG
 #############
 #LICENSE(S)
-default['newrelic']['server_monitoring']['license'] = "CHANGE_ME"
-default['newrelic']['application_monitoring']['license'] = "CHANGE_ME"
+default['newrelic']['license_key'] = nil
+default['newrelic']['server_monitoring']['license'] = node['newrelic']['license_key']
+default['newrelic']['application_monitoring']['license'] = node['newrelic']['license_key']
 
 ################
 #ADVANCED CONFIG

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "dev@escapestudios.com"
 license          "MIT"
 description      "Installs/Configures New Relic"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.4.7"
+version          "0.4.8"
 
 %w{ debian ubuntu redhat centos fedora scientific amazon }.each do |os|
 supports os

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -5,51 +5,30 @@
 # Copyright 2012-2013, Escape Studios
 #
 
-package "wget"
-
-case node[:platform]
+node.from_file(run_context.resolve_attribute("newrelic", "install"))
+case node['platform']
     when "debian", "ubuntu"
-        #trust the New Relic GPG Key
-        #this step is required to tell apt that you trust the integrity of New Relic's apt repository
-        gpg_key_id = node[:newrelic][:repository_key]
-        gpg_key_url = "http://download.newrelic.com/#{gpg_key_id}.gpg"
-
-        execute "newrelic-add-gpg-key" do
-            command "wget -O - #{gpg_key_url} | apt-key add -"
-            notifies :run, "execute[newrelic-apt-get-update]", :immediately
-            not_if "apt-key list | grep #{gpg_key_id}"
-        end
-
-        #configure the New Relic apt repository
-        remote_file "/etc/apt/sources.list.d/newrelic.list" do
-            source "http://download.newrelic.com/debian/newrelic.list"
-            owner "root"
-            group "root"
-            mode 0644
-            notifies :run, "execute[newrelic-apt-get-update]", :immediately
-            action :create_if_missing
-        end
-
-        #update the local package list
-        execute "newrelic-apt-get-update" do
-            command "apt-get update"
-            action :nothing
-        end
+      apt_repository "newrelic" do
+        uri "http://apt.newrelic.com/debian/"
+        components ["newrelic", "non-free"]
+        key "http://download.newrelic.com/#{node['newrelic']['repository_key']}.gpg"
+        action :add
+      end
     when "redhat", "centos", "fedora", "scientific", "amazon"
         #install the newrelic-repo package, which configures a new package repository for yum
-        if node[:kernel][:machine] == "x86_64"
+        if node['kernel']['machine'] == "x86_64"
             machine = "x86_64"
         else
             machine = "i386"
         end
 
-        remote_file "/tmp/newrelic-repo-5-3.noarch.rpm" do
+        remote_file "#{Chef::Config['file_cache_path'] || '/tmp'}/newrelic-repo-5-3.noarch.rpm" do
             source "http://download.newrelic.com/pub/newrelic/el5/#{machine}/newrelic-repo-5-3.noarch.rpm"
             action :create_if_missing
         end
 
         package "newrelic-repo" do
-            source "/tmp/newrelic-repo-5-3.noarch.rpm"
+            source "#{Chef::Config['file_cache_path'] || '/tmp'}/newrelic-repo-5-3.noarch.rpm"
             provider Chef::Provider::Package::Rpm
             action :install
         end

--- a/recipes/php-agent.rb
+++ b/recipes/php-agent.rb
@@ -24,110 +24,110 @@ end
 execute "newrelic-install" do
     command "newrelic-install install"
     action :nothing
-    notifies :restart, "service[#{node[:newrelic][:web_server][:service_name]}]", :delayed
+    notifies :restart, "service[#{node['newrelic']['web_server']['service_name']}]", :delayed
 end
 
 service "newrelic-daemon" do
     supports :status => true, :start => true, :stop => true, :restart => true
 end
 
+node.from_file(run_context.resolve_attribute("newrelic", "php-agent"))
 #https://newrelic.com/docs/php/newrelic-daemon-startup-modes
-log "newrelic-daemon startup mode: #{node[:newrelic][:startup_mode]}"
+Chef::Log.info("newrelic-daemon startup mode: #{node['newrelic']['startup_mode']}")
 
-if node[:newrelic][:startup_mode] == "agent"
-    #agent startup mode
+case node['newrelic']['startup_mode']
+when "external" #external startup mode
+  #configure proxy daemon settings
+  template "/etc/newrelic/newrelic.cfg" do
+      source "newrelic.cfg.erb"
+      owner "root"
+      group "root"
+      mode "0644"
+      variables(
+          :daemon_pidfile => node['newrelic']['application_monitoring']['daemon']['pidfile'],
+          :daemon_logfile => node['newrelic']['application_monitoring']['daemon']['logfile'],
+          :daemon_loglevel => node['newrelic']['application_monitoring']['daemon']['loglevel'],
+          :daemon_port => node['newrelic']['application_monitoring']['daemon']['port'],
+          :daemon_ssl => node['newrelic']['application_monitoring']['daemon']['ssl'],
+          :daemon_proxy => node['newrelic']['application_monitoring']['daemon']['proxy'],
+          :daemon_ssl_ca_path => node['newrelic']['application_monitoring']['daemon']['ssl_ca_path'],
+          :daemon_ssl_ca_bundle => node['newrelic']['application_monitoring']['daemon']['ssl_ca_bundle'],
+          :daemon_max_threads => node['newrelic']['application_monitoring']['daemon']['max_threads'],
+          :daemon_collector_host => node['newrelic']['application_monitoring']['daemon']['collector_host']
+      )
+      action :create
+      notifies :restart, "service[newrelic-daemon]", :immediately
+      notifies :restart, "service[#{node['newrelic']['web_server']['service_name']}]", :delayed
+  end
 
-    #ensure that the daemon isn't currently running
-    service "newrelic-daemon" do
-        action [:disable, :stop] #stops the service if it's running and disables it from starting at system boot time
-    end
+  service "newrelic-daemon" do
+      action [:enable, :start] #starts the service if it's not running and enables it to start at system boot time
+  end
+when "agent" #agent startup mode
+  #ensure that the daemon isn't currently running
+  service "newrelic-daemon" do
+      action [:disable, :stop] #stops the service if it's running and disables it from starting at system boot time
+  end
 
-    #ensure that the file /etc/newrelic/newrelic.cfg does not exist if it does, move it aside (or remove it)
-    execute "newrelic-backup-cfg" do
-        command "mv /etc/newrelic/newrelic.cfg /etc/newrelic/newrelic.cfg.external"
-        only_if do File.exists?("/etc/newrelic/newrelic.cfg") end
-    end
+  #ensure that the file /etc/newrelic/newrelic.cfg does not exist if it does, move it aside (or remove it)
+  execute "newrelic-backup-cfg" do
+      command "mv /etc/newrelic/newrelic.cfg /etc/newrelic/newrelic.cfg.external"
+      only_if do File.exists?("/etc/newrelic/newrelic.cfg") end
+  end
 
-    #ensure that the file /etc/newrelic/upgrade_please.key does not exist if it does, move it aside (or remove it)
-    execute "newrelic-backup-key" do
-        command "mv /etc/newrelic/upgrade_please.key /etc/newrelic/upgrade_please.key.external"
-        only_if do File.exists?("/etc/newrelic/upgrade_please.key") end
-    end
+  #ensure that the file /etc/newrelic/upgrade_please.key does not exist if it does, move it aside (or remove it)
+  execute "newrelic-backup-key" do
+      command "mv /etc/newrelic/upgrade_please.key /etc/newrelic/upgrade_please.key.external"
+      only_if do File.exists?("/etc/newrelic/upgrade_please.key") end
+  end
 
-    #configure New Relic INI file and set the daemon related options (documented at /usr/lib/newrelic-php5/scripts/newrelic.ini.template)
-    #and restart the web server in order to pick up the new settings
-    template "#{node[:php][:ext_conf_dir]}/newrelic.ini" do
-        source "newrelic.ini.php.erb"
-        owner "root"
-        group "root"
-        mode "0644"
-        variables(
-            :enabled => node[:newrelic][:application_monitoring][:enabled],
-            :license => node[:newrelic][:application_monitoring][:license],
-            :logfile => node[:newrelic][:application_monitoring][:logfile],
-            :loglevel => node[:newrelic][:application_monitoring][:loglevel],
-            :appname => node[:newrelic][:application_monitoring][:appname],
-            :daemon_logfile => node[:newrelic][:application_monitoring][:daemon][:logfile],
-            :daemon_loglevel => node[:newrelic][:application_monitoring][:daemon][:loglevel],
-            :daemon_port => node[:newrelic][:application_monitoring][:daemon][:port],
-            :daemon_max_threads => node[:newrelic][:application_monitoring][:daemon][:max_threads],
-            :daemon_ssl => node[:newrelic][:application_monitoring][:daemon][:ssl],
-            :daemon_ssl_ca_path => node[:newrelic][:application_monitoring][:daemon][:ssl_ca_path],
-            :daemon_ssl_ca_bundle => node[:newrelic][:application_monitoring][:daemon][:ssl_ca_bundle],
-            :daemon_proxy => node[:newrelic][:application_monitoring][:daemon][:proxy],
-            :daemon_pidfile => node[:newrelic][:application_monitoring][:daemon][:pidfile],
-            :daemon_location => node[:newrelic][:application_monitoring][:daemon][:location],
-            :daemon_collector_host => node[:newrelic][:application_monitoring][:daemon][:collector_host],
-            :daemon_dont_launch => node[:newrelic][:application_monitoring][:daemon][:dont_launch],
-            :capture_params => node[:newrelic][:application_monitoring][:capture_params],
-            :ignored_params => node[:newrelic][:application_monitoring][:ignored_params],
-            :error_collector_enable => node[:newrelic][:application_monitoring][:error_collector][:enable],
-            :error_collector_record_database_errors => node[:newrelic][:application_monitoring][:error_collector][:record_database_errors],
-            :error_collector_prioritize_api_errors => node[:newrelic][:application_monitoring][:error_collector][:prioritize_api_errors],
-            :browser_monitoring_auto_instrument => node[:newrelic][:application_monitoring][:browser_monitoring][:auto_instrument],
-            :transaction_tracer_enable => node[:newrelic][:application_monitoring][:transaction_tracer][:enable],
-            :transaction_tracer_threshold => node[:newrelic][:application_monitoring][:transaction_tracer][:threshold],
-            :transaction_tracer_detail => node[:newrelic][:application_monitoring][:transaction_tracer][:detail],
-            :transaction_tracer_slow_sql => node[:newrelic][:application_monitoring][:transaction_tracer][:slow_sql],
-            :transaction_tracer_stack_trace_threshold => node[:newrelic][:application_monitoring][:transaction_tracer][:stack_trace_threshold],
-            :transaction_tracer_explain_threshold => node[:newrelic][:application_monitoring][:transaction_tracer][:explain_threshold],
-            :transaction_tracer_record_sql => node[:newrelic][:application_monitoring][:transaction_tracer][:record_sql],
-            :transaction_tracer_custom => node[:newrelic][:application_monitoring][:transaction_tracer][:custom],
-            :framework => node[:newrelic][:application_monitoring][:framework],
-            :webtransaction_name_remove_trailing_path => node[:newrelic][:application_monitoring][:webtransaction][:name][:remove_trailing_path],
-            :webtransaction_name_functions => node[:newrelic][:application_monitoring][:webtransaction][:name][:functions],
-            :webtransaction_name_files => node[:newrelic][:application_monitoring][:webtransaction][:name][:files]
-        )
-        action :create
-        notifies :restart, "service[#{node[:newrelic][:web_server][:service_name]}]", :delayed
-    end
+  #configure New Relic INI file and set the daemon related options (documented at /usr/lib/newrelic-php5/scripts/newrelic.ini.template)
+  #and restart the web server in order to pick up the new settings
+  template "#{node['php']['ext_conf_dir']}/newrelic.ini" do
+      source "newrelic.ini.php.erb"
+      owner "root"
+      group "root"
+      mode "0644"
+      variables(
+          :enabled => node['newrelic']['application_monitoring']['enabled'],
+          :license => node['newrelic']['application_monitoring']['license'],
+          :logfile => node['newrelic']['application_monitoring']['logfile'],
+          :loglevel => node['newrelic']['application_monitoring']['loglevel'],
+          :appname => node['newrelic']['application_monitoring']['appname'],
+          :daemon_logfile => node['newrelic']['application_monitoring']['daemon']['logfile'],
+          :daemon_loglevel => node['newrelic']['application_monitoring']['daemon']['loglevel'],
+          :daemon_port => node['newrelic']['application_monitoring']['daemon']['port'],
+          :daemon_max_threads => node['newrelic']['application_monitoring']['daemon']['max_threads'],
+          :daemon_ssl => node['newrelic']['application_monitoring']['daemon']['ssl'],
+          :daemon_ssl_ca_path => node['newrelic']['application_monitoring']['daemon']['ssl_ca_path'],
+          :daemon_ssl_ca_bundle => node['newrelic']['application_monitoring']['daemon']['ssl_ca_bundle'],
+          :daemon_proxy => node['newrelic']['application_monitoring']['daemon']['proxy'],
+          :daemon_pidfile => node['newrelic']['application_monitoring']['daemon']['pidfile'],
+          :daemon_location => node['newrelic']['application_monitoring']['daemon']['location'],
+          :daemon_collector_host => node['newrelic']['application_monitoring']['daemon']['collector_host'],
+          :daemon_dont_launch => node['newrelic']['application_monitoring']['daemon']['dont_launch'],
+          :capture_params => node['newrelic']['application_monitoring']['capture_params'],
+          :ignored_params => node['newrelic']['application_monitoring']['ignored_params'],
+          :error_collector_enable => node['newrelic']['application_monitoring']['error_collector']['enable'],
+          :error_collector_record_database_errors => node['newrelic']['application_monitoring']['error_collector']['record_database_errors'],
+          :error_collector_prioritize_api_errors => node['newrelic']['application_monitoring']['error_collector']['prioritize_api_errors'],
+          :browser_monitoring_auto_instrument => node['newrelic']['application_monitoring']['browser_monitoring']['auto_instrument'],
+          :transaction_tracer_enable => node['newrelic']['application_monitoring']['transaction_tracer']['enable'],
+          :transaction_tracer_threshold => node['newrelic']['application_monitoring']['transaction_tracer']['threshold'],
+          :transaction_tracer_detail => node['newrelic']['application_monitoring']['transaction_tracer']['detail'],
+          :transaction_tracer_slow_sql => node['newrelic']['application_monitoring']['transaction_tracer']['slow_sql'],
+          :transaction_tracer_stack_trace_threshold => node['newrelic']['application_monitoring']['transaction_tracer']['stack_trace_threshold'],
+          :transaction_tracer_explain_threshold => node['newrelic']['application_monitoring']['transaction_tracer']['explain_threshold'],
+          :transaction_tracer_record_sql => node['newrelic']['application_monitoring']['transaction_tracer']['record_sql'],
+          :transaction_tracer_custom => node['newrelic']['application_monitoring']['transaction_tracer']['custom'],
+          :framework => node['newrelic']['application_monitoring']['framework'],
+          :webtransaction_name_remove_trailing_path => node['newrelic']['application_monitoring']['webtransaction']['name']['remove_trailing_path'],
+          :webtransaction_name_functions => node['newrelic']['application_monitoring']['webtransaction']['name']['functions'],
+          :webtransaction_name_files => node['newrelic']['application_monitoring']['webtransaction']['name']['files']
+      )
+      action :create
+      notifies :restart, "service[#{node['newrelic']['web_server']['service_name']}]", :delayed
+  end
 else
-    #external startup mode
-
-    #configure proxy daemon settings
-    template "/etc/newrelic/newrelic.cfg" do
-        source "newrelic.cfg.erb"
-        owner "root"
-        group "root"
-        mode "0644"
-        variables(
-            :daemon_pidfile => node[:newrelic][:application_monitoring][:daemon][:pidfile],
-            :daemon_logfile => node[:newrelic][:application_monitoring][:daemon][:logfile],
-            :daemon_loglevel => node[:newrelic][:application_monitoring][:daemon][:loglevel],
-            :daemon_port => node[:newrelic][:application_monitoring][:daemon][:port],
-            :daemon_ssl => node[:newrelic][:application_monitoring][:daemon][:ssl],
-            :daemon_proxy => node[:newrelic][:application_monitoring][:daemon][:proxy],
-            :daemon_ssl_ca_path => node[:newrelic][:application_monitoring][:daemon][:ssl_ca_path],
-            :daemon_ssl_ca_bundle => node[:newrelic][:application_monitoring][:daemon][:ssl_ca_bundle],
-            :daemon_max_threads => node[:newrelic][:application_monitoring][:daemon][:max_threads],
-            :daemon_collector_host => node[:newrelic][:application_monitoring][:daemon][:collector_host]
-        )
-        action :create
-        notifies :restart, "service[newrelic-daemon]", :immediately
-        notifies :restart, "service[#{node[:newrelic][:web_server][:service_name]}]", :delayed
-    end
-
-    service "newrelic-daemon" do
-        action [:enable, :start] #starts the service if it's not running and enables it to start at system boot time
-    end
+  Chef::Application.fatal!("#{node['newrelic']['startup_mode']} is not a valid newrelic php-agent startup mode.")
 end

--- a/recipes/python-agent.rb
+++ b/recipes/python-agent.rb
@@ -10,11 +10,12 @@ include_recipe "python::pip"
 #install latest python agent
 python_pip "newrelic" do
     action :install
-    if node[:newrelic][:python_version] != "latest"
-        version "#{node[:newrelic][:python_version]}"
+    if node['newrelic']['python_version'] != "latest"
+        version node['newrelic']['python_version']
     end
 end
 
+node.from_file(run_context.resolve_attribute("newrelic", "python-agent"))
 #configure your New Relic license key
 template "/etc/newrelic/newrelic.ini" do
     source "newrelic.ini.python.erb"
@@ -22,22 +23,22 @@ template "/etc/newrelic/newrelic.ini" do
     group "root"
     mode "0644"
     variables(
-        :license => node[:newrelic][:application_monitoring][:license],
-        :appname => node[:newrelic][:application_monitoring][:appname],
-        :enabled => node[:newrelic][:application_monitoring][:enabled],
-        :logfile => node[:newrelic][:application_monitoring][:logfile],
-        :loglevel => node[:newrelic][:application_monitoring][:loglevel],
-        :daemon_ssl => node[:newrelic][:application_monitoring][:daemon][:ssl],        
-        :capture_params => node[:newrelic][:application_monitoring][:capture_params],
-        :ignored_params => node[:newrelic][:application_monitoring][:ignored_params],
-        :transaction_tracer_enable => node[:newrelic][:application_monitoring][:transaction_tracer][:enable],
-        :transaction_tracer_threshold => node[:newrelic][:application_monitoring][:transaction_tracer][:threshold],
-        :transaction_tracer_record_sql => node[:newrelic][:application_monitoring][:transaction_tracer][:record_sql],
-        :transaction_tracer_stack_trace_threshold => node[:newrelic][:application_monitoring][:transaction_tracer][:stack_trace_threshold],
-        :transaction_tracer_slow_sql => node[:newrelic][:application_monitoring][:transaction_tracer][:slow_sql],
-        :transaction_tracer_explain_threshold => node[:newrelic][:application_monitoring][:transaction_tracer][:explain_threshold],
-        :error_collector_enable => node[:newrelic][:application_monitoring][:error_collector][:enable],
-        :browser_monitoring_auto_instrument => node[:newrelic][:application_monitoring][:browser_monitoring][:auto_instrument]
+        :license => node['newrelic']['application_monitoring']['license'],
+        :appname => node['newrelic']['application_monitoring']['appname'],
+        :enabled => node['newrelic']['application_monitoring']['enabled'],
+        :logfile => node['newrelic']['application_monitoring']['logfile'],
+        :loglevel => node['newrelic']['application_monitoring']['loglevel'],
+        :daemon_ssl => node['newrelic']['application_monitoring']['daemon']['ssl'],        
+        :capture_params => node['newrelic']['application_monitoring']['capture_params'],
+        :ignored_params => node['newrelic']['application_monitoring']['ignored_params'],
+        :transaction_tracer_enable => node['newrelic']['application_monitoring']['transaction_tracer']['enable'],
+        :transaction_tracer_threshold => node['newrelic']['application_monitoring']['transaction_tracer']['threshold'],
+        :transaction_tracer_record_sql => node['newrelic']['application_monitoring']['transaction_tracer']['record_sql'],
+        :transaction_tracer_stack_trace_threshold => node['newrelic']['application_monitoring']['transaction_tracer']['stack_trace_threshold'],
+        :transaction_tracer_slow_sql => node['newrelic']['application_monitoring']['transaction_tracer']['slow_sql'],
+        :transaction_tracer_explain_threshold => node['newrelic']['application_monitoring']['transaction_tracer']['explain_threshold'],
+        :error_collector_enable => node['newrelic']['application_monitoring']['error_collector']['enable'],
+        :browser_monitoring_auto_instrument => node['newrelic']['application_monitoring']['browser_monitoring']['auto_instrument']
     )
     action :create
 end

--- a/recipes/server-monitor.rb
+++ b/recipes/server-monitor.rb
@@ -10,6 +10,7 @@ package "newrelic-sysmond" do
     action :install
 end
 
+node.from_file(run_context.resolve_attribute("newrelic", "default"))
 #configure your New Relic license key
 template "/etc/newrelic/nrsysmond.cfg" do
     source "nrsysmond.cfg.erb"
@@ -17,16 +18,16 @@ template "/etc/newrelic/nrsysmond.cfg" do
     group "newrelic"
     mode "640"
     variables(
-        :license => node[:newrelic][:server_monitoring][:license],
-        :logfile => node[:newrelic][:server_monitoring][:logfile],
-        :loglevel => node[:newrelic][:server_monitoring][:loglevel],
-        :proxy => node[:newrelic][:server_monitoring][:proxy],
-        :ssl => node[:newrelic][:server_monitoring][:ssl],
-        :ssl_ca_path => node[:newrelic][:server_monitoring][:ssl_ca_path],
-        :ssl_ca_bundle => node[:newrelic][:server_monitoring][:ssl_ca_bundle],
-        :pidfile => node[:newrelic][:server_monitoring][:pidfile],
-        :collector_host => node[:newrelic][:server_monitoring][:collector_host],
-        :timeout => node[:newrelic][:server_monitoring][:timeout]
+        :license => node['newrelic']['server_monitoring']['license'],
+        :logfile => node['newrelic']['server_monitoring']['logfile'],
+        :loglevel => node['newrelic']['server_monitoring']['loglevel'],
+        :proxy => node['newrelic']['server_monitoring']['proxy'],
+        :ssl => node['newrelic']['server_monitoring']['ssl'],
+        :ssl_ca_path => node['newrelic']['server_monitoring']['ssl_ca_path'],
+        :ssl_ca_bundle => node['newrelic']['server_monitoring']['ssl_ca_bundle'],
+        :pidfile => node['newrelic']['server_monitoring']['pidfile'],
+        :collector_host => node['newrelic']['server_monitoring']['collector_host'],
+        :timeout => node['newrelic']['server_monitoring']['timeout']
     )
     notifies :restart, "service[newrelic-sysmond]"
 end


### PR DESCRIPTION
Hello, I made a couple of changes.
I believe they are all backwards compatible as it's all style..
- add `license_key` meta attribute that is then set to both current app and server monitoring attributes.
  This gives typical users one smaller target but keeps the same flexibility as app and server can be defined separately.

e.g. 

``` json
{
  "default_attributes": {
        "newrelic": {
          "license_key": "123456789123456789",
          "web_server": { "service_name": "nginx" }
  }
}
```

Rather than:

``` json
{
  "default_attributes": {
        "newrelic": {
          "server_monitoring": {
            "license_key": "123456789123456789"
          },
          "application_monitoring": {
             "license_key": "123456789123456789"
          }, 
          "web_server": { "service_name": "nginx" }
  }
}
```
- Use apt_repository LWRP for installing on debian variants - this was a large removal of code. It added a lot of complexity when a [builtin LWRP](http://docs.opscode.com/lwrp_apt.html#apt-repository) can be used instead.
  This should be faster and more robust.
- Case statement for php-agent startup mode. The logic for this did not work for me.
  The case statement does.
- A number of [Foodcritic](http://acrmp.github.io/foodcritic/) lint checks did not pass. I mainly changed all attribute naming styles to be consistent, which is the big code churn in the diffs.
- I took the liberty of adding to the README and version bumping.
