### PR TITLE
Add SmartOS support for server monitoring

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -12,6 +12,16 @@
 default['newrelic']['server_monitoring']['license'] = "CHANGE_ME"
 default['newrelic']['application_monitoring']['license'] = "CHANGE_ME"
 
+default['newrelic']['service_name'] = value_for_platform(
+    'smartos' => {'default' => 'nrsysmond'},
+    'default' => 'newrelic-sysmond'
+)
+default['newrelic']['config_path'] = value_for_platform(
+    'smartos' => {'default' => '/opt/local/etc'},
+    'default' => '/etc/newrelic'
+)
+
+
 ################
 #ADVANCED CONFIG
 ################
@@ -28,6 +38,10 @@ default['newrelic']['server_monitoring']['timeout'] = nil
 default['newrelic']['server_monitoring']['windows_version'] = "2.0.0.198"
 default['newrelic']['server_monitoring']['windows64_checksum'] = "5a8f3f5e8f15997463430401756d377c321c8899c2790ca85e5587a5b643651e"
 default['newrelic']['server_monitoring']['windows32_checksum'] = "ac2b65eecaad461fdd2e4386e3e4c9f96ea940b35bdf7a8c532c21dbd1c99ff0"
+default['newrelic']['server_monitoring']['config_file_group'] = value_for_platform(
+    'smartos' => {'default' => 'root'},
+    'default' => 'newrelic'
+)
 
 #application monitoring
 default['newrelic']['application_monitoring']['enabled'] = nil

--- a/recipes/server-monitor.rb
+++ b/recipes/server-monitor.rb
@@ -7,16 +7,16 @@
 
 #install the server monitor
 case node['platform']
-    when "debian", "ubuntu", "redhat", "centos", "fedora", "scientific", "amazon"
-        package "newrelic-sysmond" do
+    when "debian", "ubuntu", "redhat", "centos", "fedora", "scientific", "amazon", "smartos"
+        package node['newrelic']['service_name'] do
             action :install
         end
 
         #configure your New Relic license key
-        template "/etc/newrelic/nrsysmond.cfg" do
+        template "#{node['newrelic']['config_path']}/nrsysmond.cfg" do
             source "nrsysmond.cfg.erb"
             owner "root"
-            group "newrelic"
+            group node['newrelic']['server_monitoring']['config_file_group']
             mode "640"
             variables(
                 :license => node['newrelic']['server_monitoring']['license'],
@@ -30,7 +30,7 @@ case node['platform']
                 :collector_host => node['newrelic']['server_monitoring']['collector_host'],
                 :timeout => node['newrelic']['server_monitoring']['timeout']
             )
-            notifies :restart, "service[newrelic-sysmond]"
+            notifies :restart, "service[#{node['newrelic']['service_name']}]"
         end
   when "windows"
     include_recipe "ms_dotnet4"
@@ -54,7 +54,7 @@ case node['platform']
     end
 end
 
-service "newrelic-sysmond" do
+service node['newrelic']['service_name'] do
     supports :status => true, :start => true, :stop => true, :restart => true
     action [:enable, :start] #starts the service if it's not running and enables it to start at system boot time
 end


### PR DESCRIPTION
Moving a few things into value_for_platform evaluations to populate default node attributes, so that the recipes can continue to be simple.
