### PR TITLE
added the recipe attributes for the php, python, and dotnet agents...

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,13 +104,16 @@ Attributes
 * `node['newrelic']['repository_key']` - The New Relic repository key, defaults to "548C16BF"
 
 ## php-agent.rb:
+* `node['newrelic']['php_recipe']` - The php recipe to include for the php agent, defaults to "php"
 * `node['newrelic']['startup_mode']` - The newrelic-daemon startup mode ("agent"/"external"), defaults to "agent"
 * `node['newrelic']['web_server']['service_name']` - The web server service name, defaults to "apache2"
 
 ## python-agent.rb:
+* `node['newrelic']['python_recipe']` - The python recipe to include for the python agent, defaults to "python::pip"
 * `node['newrelic']['python_version']` - Defaults to "latest". Version numbers can be found at http://download.newrelic.com/python_agent/release/
 
 ## dotnet-agent.rb:
+* `node['newrelic']['dotnet_recipe']` - The dotnet recipe to include for the php agaent, defaults to "ms_dotnet4"
 * `node['newrelic']['https_download']` - The URL to download the MSI installer from New Relic. Default is to pull "latest"
 * `node['newrelic']['install_level']` - The install version of the .NET Agent. Default is '1' but can use '50' for a complete installation
 

--- a/attributes/dotnet-agent.rb
+++ b/attributes/dotnet-agent.rb
@@ -7,3 +7,4 @@
 
 default['newrelic']['https_download'] = 'https://download.newrelic.com/dot_net_agent/release/x64'
 default['newrelic']['install_level'] = '1'
+default['newrelic']['dotnet_recipe'] = 'ms_dotnet4'

--- a/attributes/php-agent.rb
+++ b/attributes/php-agent.rb
@@ -5,5 +5,6 @@
 # Copyright 2012-2013, Escape Studios
 #
 
-default['newrelic']['startup_mode'] = "agent"
-default['newrelic']['web_server']['service_name'] = "apache2"
+default['newrelic']['startup_mode'] = 'agent'
+default['newrelic']['web_server']['service_name'] = 'apache2'
+default['newrelic']['php_recipe'] = 'php'

--- a/attributes/python-agent.rb
+++ b/attributes/python-agent.rb
@@ -6,3 +6,4 @@
 #
 
 default['newrelic']['python_version'] = "latest"
+default['newrelic']['python_recipe'] = 'python::pip'

--- a/recipes/dotnet-agent.rb
+++ b/recipes/dotnet-agent.rb
@@ -5,7 +5,7 @@
 # Copyright 2012-2013, Escape Studios
 #
 
-include_recipe "ms_dotnet4"
+include_recipe node['newrelic']['dotnet_recipe']
 
 windows_package "Install New Relic .NET Agent" do
     source node['newrelic']['https_download']

--- a/recipes/php-agent.rb
+++ b/recipes/php-agent.rb
@@ -5,7 +5,7 @@
 # Copyright 2012-2013, Escape Studios
 #
 
-include_recipe "php"
+include_recipe node['newrelic']['php_recipe']
 
 #the older version (3.0) had a bug in the init scripts that when it shut down the daemon it would also kill dpkg as it was trying to upgrade
 #let's remove the old packages before continuing

--- a/recipes/python-agent.rb
+++ b/recipes/python-agent.rb
@@ -5,7 +5,7 @@
 # Copyright 2012-2013, Escape Studios
 #
 
-include_recipe "python::pip"
+include_recipe node['newrelic']['python_recipe']
 
 #install latest python agent
 python_pip "newrelic" do

--- a/recipes/server-monitor.rb
+++ b/recipes/server-monitor.rb
@@ -37,7 +37,7 @@ case node['platform']
             action [:enable, :start] #starts the service if it's not running and enables it to start at system boot time
         end
     when "windows"
-        include_recipe "ms_dotnet4"
+        include_recipe node['newrelic']['dotnet_recipe']
         
         if node['kernel']['machine'] == "x86_64"
                 windows_package "New Relic Server Monitor" do


### PR DESCRIPTION
...in order to customize recipes the agents depend upon.

This is a duplicate of #41 Add a default recipe for php installation, but with the work completed. Please let me know if it's ok and if/when you push it to the community site. Thanks!
