### PR TITLE
Added hostname field to server monitoring config file

### DIFF
--- a/recipes/server-monitor.rb
+++ b/recipes/server-monitor.rb
@@ -27,7 +27,8 @@ case node['platform']
                 :ssl_ca_bundle => node['newrelic']['server_monitoring']['ssl_ca_bundle'],
                 :pidfile => node['newrelic']['server_monitoring']['pidfile'],
                 :collector_host => node['newrelic']['server_monitoring']['collector_host'],
-                :timeout => node['newrelic']['server_monitoring']['timeout']
+                :timeout => node['newrelic']['server_monitoring']['timeout'],
+                :hostname => node['newrelic']['server_monitoring']['hostname']
             )
             notifies :restart, "service[#{node['newrelic']['service_name']}]"
         end

--- a/templates/default/nrsysmond.cfg.erb
+++ b/templates/default/nrsysmond.cfg.erb
@@ -161,3 +161,14 @@ collector_host=<%= @collector_host %>
 <% else %>
 timeout=<%= @timeout %>
 <% end %>
+
+#
+# Option : hostname
+# Value  : The server name reported by NewRelic server monitoring
+# Default: OS-level hostname
+#
+<% if @hostname.nil? %>
+#
+<% else %>
+hostname=<%= @hostname %>
+<% end %>


### PR DESCRIPTION
Newrelic uses the OS-level hostname by default. Need to have a quick way
to chenge it from a recipe.
