### PR TITLE
Add missing install execution of the java agent

### DIFF
--- a/recipes/java-agent.rb
+++ b/recipes/java-agent.rb
@@ -56,3 +56,8 @@ template conf_file do
     )
     action :create
 end
+
+#execution of the install
+execute "Run New Relic java agent installer" do
+    command "sudo java -jar #{node['newrelic']['install_dir']}/newrelic.jar install"
+end


### PR DESCRIPTION
Looks like java-agent.rb recipe is missing the install execution of the agent.
