### PR TITLE
Show an OpsWorks stack & hostname if this node was created by Opsworks (...

### DIFF
--- a/recipes/server-monitor.rb
+++ b/recipes/server-monitor.rb
@@ -11,6 +11,12 @@ case node['platform']
             action :install
         end
 
+        hostname = if node['opsworks']
+          "#{node['opsworks']['stack']['name'].downcase}-#{node['opsworks']['instance']['hostname']}"
+        else
+          node['newrelic']['server_monitoring']['hostname']
+        end
+
         #configure your New Relic license key
         template "#{node['newrelic']['config_path']}/nrsysmond.cfg" do
             source "nrsysmond.cfg.erb"
@@ -25,7 +31,7 @@ case node['platform']
                 :ssl => node['newrelic']['server_monitoring']['ssl'],
                 :ssl_ca_bundle => node['newrelic']['server_monitoring']['ssl_ca_bundle'],
                 :ssl_ca_path => node['newrelic']['server_monitoring']['ssl_ca_path'],
-                :hostname => node['newrelic']['server_monitoring']['hostname'],
+                :hostname => hostname,
                 :pidfile => node['newrelic']['server_monitoring']['pidfile'],
                 :collector_host => node['newrelic']['server_monitoring']['collector_host'],
                 :timeout => node['newrelic']['server_monitoring']['timeout']


### PR DESCRIPTION
Hi:

We added these tweaks to your newrelic recipe so that it works with Amazon's AWS OpsWorks - if OpsWorks is in use (detected by node['opsworks']), then the hostname now includes the OpsWorks stack as a prefix. Without this, we were having problems with data getting conflated in NewRelic - we had servers named rails-app1, rails-app2, etc., in various OpsWorks stacks (e.g., production, demo, staging, etc.), but they all showed up in NewRelic as the same rails-apps1. Now, they show up in NewRelic as production-rails-app1, demo-rails-app2, etc.

Thanks!

-- Greg
