### PR TITLE
Enabling configuration of the python-agent configuration file location

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Attributes
 ## python-agent.rb:
 * `node['newrelic']['python-agent']['python_version']` - Defaults to "latest". Version numbers can be found at http://download.newrelic.com/python_agent/release/
 * `node['newrelic']['python-agent']['python_recipe']` - The python recipe to include for the python agent, defaults to "python::pip"
+* `node['newrelic']['python-agent']['python_config_file']` - Location of the configuration file, defaults to "/etc/newrelic/newrelic.ini"
 
 ## dotnet-agent.rb:
 * `node['newrelic']['dotnet-agent']['https_download']` - The URL to download the MSI installer from New Relic. Default is to pull "latest"
@@ -153,7 +154,7 @@ Attributes
 
 eg.
 ```
-[ 
+[
    { 'app_name' => 'My Application', 'app_path' => "/path/to/app/root" }
 ]
 ```

--- a/attributes/python-agent.rb
+++ b/attributes/python-agent.rb
@@ -7,3 +7,4 @@
 
 default['newrelic']['python-agent']['python_version'] = "latest"
 default['newrelic']['python-agent']['python_recipe'] = "python::pip"
+default['newrelic']['python-agent']['python_config_file'] = "/etc/newrelic/newrelic.ini"

--- a/recipes/python-agent.rb
+++ b/recipes/python-agent.rb
@@ -18,7 +18,7 @@ python_pip "newrelic" do
 end
 
 #configure your New Relic license key
-template "/etc/newrelic/newrelic.ini" do
+template node['newrelic']['python-agent']['python_config_file'] do
     source "newrelic.ini.python.erb"
     owner "root"
     group "root"
@@ -29,7 +29,7 @@ template "/etc/newrelic/newrelic.ini" do
         :enabled => node['newrelic']['application_monitoring']['enabled'],
         :logfile => node['newrelic']['application_monitoring']['logfile'],
         :loglevel => node['newrelic']['application_monitoring']['loglevel'],
-        :daemon_ssl => node['newrelic']['application_monitoring']['daemon']['ssl'],        
+        :daemon_ssl => node['newrelic']['application_monitoring']['daemon']['ssl'],
         :capture_params => node['newrelic']['application_monitoring']['capture_params'],
         :ignored_params => node['newrelic']['application_monitoring']['ignored_params'],
         :transaction_tracer_enable => node['newrelic']['application_monitoring']['transaction_tracer']['enable'],


### PR DESCRIPTION
Hi,
Fairly simple PR to be able to configure where newrelic.ini is located with the python-agent.

Doing this mostly to use this attribute in other cookbooks when I need to expose this as an environment variable.

Thanks
