### PR TITLE
Fixed metadata syntax which added { and } as supported platforms

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description 'Installs/Configures New Relic'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '1.0.2'
 
-%w({ debian ubuntu redhat centos fedora scientific amazon windows smartos }).each do |os|
+%w{ debian ubuntu redhat centos fedora scientific amazon windows smartos }.each do |os|
   supports os
 end
 


### PR DESCRIPTION
This caused an error with Berkshelf and the `berks upload` command that looked like this:

`
Uploading newrelic (1.0.2) to: 'https://xxx.xxx.xxx:443/'
Ridley::Errors::HTTPBadRequest: {"error":["Invalid key '{' for metadata.platforms"]}
`
