### PR TITLE
Fixes 'newrelic_rpm' gem install in ruby-agent recipe

### DIFF
--- a/recipes/ruby-agent.rb
+++ b/recipes/ruby-agent.rb
@@ -9,8 +9,7 @@ include_recipe 'newrelic::repository'
 
 license = node['newrelic']['application_monitoring']['license']
 
-package 'newrelic_rpm' do
-  provider Chef::Provider::Package::RubyGem
+gem_package 'newrelic_rpm' do
   action :install
 end
 


### PR DESCRIPTION
According to Chef docs, using `gem_package` is the same as using `Chef::Provider::Package::Rubygems`; please see [gem_package resource](http://docs.opscode.com/resource_gem_package.html) for verification.

Using Chef 11.12.2, this recipe raises an error stating that `Chef::Provider::Package::RubyGem` is an undefined constant (**notice RubyGem is singluar!**). Perhaps the provider name recently changed in this version of Chef. Regardless, I believe `gem_package` should be used because it abstracts the provider class name.
