### PR TITLE
Meet-me plugin service name is wrong

### DIFF
--- a/attributes/meetme-plugin.rb
+++ b/attributes/meetme-plugin.rb
@@ -6,7 +6,7 @@
 #
 
 default['newrelic']['meetme-plugin']['python_recipe'] = 'python::pip'
-default['newrelic']['meetme-plugin']['service_name'] = 'newrelic-meetme-plugin'
+default['newrelic']['meetme-plugin']['service_name'] = 'newrelic-plugin-agent'
 default['newrelic']['meetme-plugin']['wake_interval'] = 60
 default['newrelic']['meetme-plugin']['proxy'] = nil
 default['newrelic']['meetme-plugin']['services'] = {}


### PR DESCRIPTION
Service name is used to install plugin so installation fails.
Maybe it can be done by separating this in two attributes, one for package and other for service.

Also, on one of my servers installation of meetme plugin failed on compilation of `pyyaml` until I install python-dev package, so maybe it would be good to include `python` recipe in `meetme-plugin` recipe in addition to `python::pip`.
