### PR TITLE
Allow set custom path to meetme agent, change default binary name

### DIFF
--- a/attributes/meetme-plugin.rb
+++ b/attributes/meetme-plugin.rb
@@ -7,6 +7,7 @@
 
 default['newrelic']['meetme-plugin']['python_recipe'] = 'python::pip'
 default['newrelic']['meetme-plugin']['service_name'] = 'newrelic-meetme-plugin'
+default['newrelic']['meetme-plugin']['bin_file'] = '/usr/local/bin/newrelic-plugin-agent'
 default['newrelic']['meetme-plugin']['wake_interval'] = 60
 default['newrelic']['meetme-plugin']['proxy'] = nil
 default['newrelic']['meetme-plugin']['services'] = {}

--- a/recipes/meetme-plugin.rb
+++ b/recipes/meetme-plugin.rb
@@ -72,7 +72,8 @@ end
 # init script
 variables = {
   :config_file => node['newrelic']['meetme-plugin']['config_file'],
-  :pid_file => node['newrelic']['meetme-plugin']['pid_file']
+  :pid_file => node['newrelic']['meetme-plugin']['pid_file'],
+  :bin_file => node['newrelic']['meetme-plugin']['bin_file']
 }
 
 case node['platform']

--- a/templates/debian/plugin/meetme/newrelic-plugin-agent.erb
+++ b/templates/debian/plugin/meetme/newrelic-plugin-agent.erb
@@ -14,7 +14,7 @@
 
 NAME=newrelic_plugin_agent
 CONFIG=<%= @config_file %>
-DAEMON=/usr/local/bin/newrelic_plugin_agent
+DAEMON=<%= @bin_file %>
 DAEMON_OPTS="-c $CONFIG"
 DESC="New Relic Plugin Agent"
 PIDFILE=<%= @pid_file %>

--- a/templates/default/plugin/meetme/newrelic-plugin-agent.erb
+++ b/templates/default/plugin/meetme/newrelic-plugin-agent.erb
@@ -9,7 +9,7 @@
 . /etc/init.d/functions
 
 # Application
-APP="/usr/bin/newrelic_plugin_agent"
+APP="<%= @bin_file %>"
 
 # PID File
 PID_FILE=<%= @pid_file %>

--- a/templates/ubuntu/plugin/meetme/newrelic-plugin-agent.erb
+++ b/templates/ubuntu/plugin/meetme/newrelic-plugin-agent.erb
@@ -14,7 +14,7 @@
 
 NAME=newrelic_plugin_agent
 CONFIG=<%= @config_file %>
-DAEMON=/usr/local/bin/newrelic_plugin_agent
+DAEMON=<%= @bin_file %>
 DAEMON_OPTS="-c $CONFIG"
 DESC="New Relic Plugin Agent"
 PIDFILE=<%= @pid_file %>


### PR DESCRIPTION
I recently noticed that meetme agent has not works, because binary file name changed

``` sh
# /etc/init.d/newrelic-plugin-agent start
 * Starting New Relic Plugin Agent newrelic_plugin_agent
 * /usr/local/bin/newrelic_plugin_agent not found
```
