### PR TITLE
Java agent installation path ISSUE: 88

### DIFF
--- a/recipes/java-agent.rb
+++ b/recipes/java-agent.rb
@@ -79,6 +79,6 @@ end
 
 # execution of the install
 execute 'newrelic-install' do
-  command "sudo java -jar #{node['newrelic']['java-agent']['install_dir']}/newrelic.jar install"
+  command "sudo java -jar #{local_file} install"
   only_if { node['newrelic']['java-agent']['execute_install'] }
 end


### PR DESCRIPTION
This pull request is related to issue #88.

Instead of the hardcoded path installation should use the same path of the downloaded file (variable local_file).
