### PR TITLE
Name of the meetme executable was changed.

### DIFF
--- a/templates/debian/plugin/meetme/newrelic-plugin-agent.erb
+++ b/templates/debian/plugin/meetme/newrelic-plugin-agent.erb
@@ -14,7 +14,7 @@
 
 NAME=newrelic_plugin_agent
 CONFIG=<%= @config_file %>
-DAEMON=/usr/local/bin/newrelic_plugin_agent
+DAEMON=/usr/local/bin/newrelic-plugin-agent
 DAEMON_OPTS="-c $CONFIG"
 DESC="New Relic Plugin Agent"
 PIDFILE=<%= @pid_file %>

--- a/templates/default/plugin/meetme/newrelic-plugin-agent.erb
+++ b/templates/default/plugin/meetme/newrelic-plugin-agent.erb
@@ -9,7 +9,7 @@
 . /etc/init.d/functions
 
 # Application
-APP="/usr/bin/newrelic_plugin_agent"
+APP="/usr/bin/newrelic-plugin-agent"
 
 # PID File
 PID_FILE=<%= @pid_file %>

--- a/templates/ubuntu/plugin/meetme/newrelic-plugin-agent.erb
+++ b/templates/ubuntu/plugin/meetme/newrelic-plugin-agent.erb
@@ -14,7 +14,7 @@
 
 NAME=newrelic_plugin_agent
 CONFIG=<%= @config_file %>
-DAEMON=/usr/local/bin/newrelic_plugin_agent
+DAEMON=/usr/local/bin/newrelic-plugin-agent
 DAEMON_OPTS="-c $CONFIG"
 DESC="New Relic Plugin Agent"
 PIDFILE=<%= @pid_file %>


### PR DESCRIPTION
Adjusted the template files to reflect the recent name change of the
meetme plugin executable. It is now `newrelic-plugin-agent` instead of
`newrelic_plugin_agent`.
