### PR TITLE
bugfix: bad local_file path on installation

### DIFF
--- a/recipes/java-agent.rb
+++ b/recipes/java-agent.rb
@@ -18,12 +18,14 @@ directory node['newrelic']['java-agent']['install_dir'] do
   action :create
 end
 
-local_file = "#{node['newrelic']['java-agent']['install_dir']}/#{node['newrelic']['java-agent']['jar_file']}"
+remote_file = "#{node['newrelic']['java-agent']['install_dir']}/#{node['newrelic']['java-agent']['jar_file']}"
+local_file = "#{node['newrelic']['java-agent']['install_dir']}/newrelic.jar"
 
-remote_file local_file do
+remote_file remote_file do
   source node['newrelic']['java-agent']['https_download']
   owner node['newrelic']['java-agent']['app_user']
   group node['newrelic']['java-agent']['app_group']
+  path  local_file
   mode 0664
   not_if { File.exist?(local_file) }
 end


### PR DESCRIPTION
My previous request pull created a installation bug where the #{node['newrelic']['java-agent']['install_dir']}/newrelic.jar wasn't being created with the same value produced by the newrelic's installation agent. eg: `NR_JAR=/opt/tomcat-7.0.53/newrelic/newrelic.jar; export NR_JAR``

bug was fixed using the path attribute of the remote_file chef provider (renaming the downloaded file to the correct name)
