### PR TITLE
Removing PHP recipe execution from php-agent installation.

### DIFF
--- a/recipes/php-agent.rb
+++ b/recipes/php-agent.rb
@@ -6,7 +6,6 @@
 #
 
 include_recipe 'newrelic::repository'
-include_recipe node['newrelic']['php-agent']['php_recipe']
 
 license = node['newrelic']['application_monitoring']['license']
 


### PR DESCRIPTION
Any system installing the php plugin agent is already going to have php
installed so this step is redundant and breaks attempts to make the
agent installation stand-alone.

**Explanation**

Please take out including the php recipe.  This is not necessary and does not belong in this recipe.  This belongs in a role/run list.

I want to be able to run this recipe as a standalone without installing other things that the agent depends on.  In almost no circumstance am I going to install the php agent without php already being installed.

The problem is I'm using a php wrapper cookbook to support newer versions of PHP on Amazon but I don't want the steps being taken in that cookbook to run when all I want this the php agent to be installed.
