### PR TITLE
Change default PHP 'agent_action' to upgrade

### DIFF
--- a/attributes/php-agent.rb
+++ b/attributes/php-agent.rb
@@ -13,7 +13,7 @@ if node.attribute?('php')
   end
 end
 
-default['newrelic']['php-agent']['agent_action'] = :install
+default['newrelic']['php-agent']['agent_action'] = :upgrade
 default['newrelic']['php-agent']['install_silently'] = false
 default['newrelic']['php-agent']['startup_mode'] = 'agent'
 default['newrelic']['php-agent']['web_server']['service_name'] = 'apache2'


### PR DESCRIPTION
Using 'install', the version is inherited from the previous resource of the same name, one we just tried to remove:

``` ruby
package 'newrelic-php5' do
  action :remove
  version '3.0.5.95'
end

# install/update latest php agent
package 'newrelic-php5' do
  action node['newrelic']['php-agent']['agent_action']
  notifies :run, 'execute[newrelic-install]', :immediately
end
```

By setting `node['newrelic']['php-agent']['agent_action']` to 'upgrade' Chef will install the latest version of the agent package.
