### PR TITLE
package[newrelic-php5] fresh install fails due to resource cloning

### DIFF
--- a/recipes/php-agent.rb
+++ b/recipes/php-agent.rb
@@ -11,7 +11,8 @@ license = node['newrelic']['application_monitoring']['license']
 
 # the older version (3.0) had a bug in the init scripts that when it shut down the daemon it would also kill dpkg as it was trying to upgrade
 # let's remove the old packages before continuing
-package 'newrelic-php5' do
+package 'newrelic-php5-broken' do
+  package_name 'newrelic-php5'
   action :remove
   version '3.0.5.95'
 end


### PR DESCRIPTION
Improved: rename removal of newrelic-php5=3.0.5.95 to unique resource
Improved: install of newrelic-php5 does not inherit version '3.0.5.95'
