### PR TITLE
Explicitly added ms_dotnet4 in metadata to be bootstrapped properly on Windows Hosts

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -8,10 +8,10 @@ version '1.3.1'
 
 %w( debian ubuntu redhat centos fedora scientific amazon windows smartos ).each do |os|
   supports os
+  depends 'ms_dotnet4' if os == 'windows'
 end
 
 depends 'python'
-depends 'ms_dotnet4'
 
 recommends 'php'
 recommends 'curl'


### PR DESCRIPTION
Tried to bootstrap a windows host today and got the following error:

[2014-08-18T10:39:13-04:00] WARN: MissingCookbookDependency:
Recipe `ms_dotnet4` is not in the run_list, and cookbook 'ms_dotnet4'
is not a dependency of any cookbook in the run_list.  To load this recipe,
first add a dependency on cookbook 'ms_dotnet4' in the cookbook you're
including it from in that cookbook's metadata.
# 
# Recipe Compile Error in c:/chef/cache/cookbooks/newrelic/recipes/server-monitor-agent.rb
## Chef::Exceptions::CookbookNotFound

Cookbook ms_dotnet4 not found. If you're loading ms_dotnet4 from another cookbook, make sure you configure the dependency in your metadata
## Cookbook Trace:

  c:/chef/cache/cookbooks/newrelic/recipes/server-monitor-agent.rb:45:in `from_file'
## Relevant File Content:

c:/chef/cache/cookbooks/newrelic/recipes/server-monitor-agent.rb:

 38:    end
 39:  
 40:    service node['newrelic']['server-monitor-agent']['service_name'] do
 41:      supports :status => true, :start => true, :stop => true, :restart => true
 42:      action node['newrelic']['server-monitor-agent']['service_actions']
 43:    end
 44:  when 'windows'
 45>>   include_recipe node['newrelic']['dotnet-agent']['dotnet_recipe']
 46:  
 47:    if node['kernel']['machine'] == 'x86_64'
 48:      windows_package 'New Relic Server Monitor' do
 49:        source "http://download.newrelic.com/windows_server_monitor/release/NewRelicServerMonitor_x64_#{node['newrelic']['server-monitor-agent']['windows_version']}.msi"
 50:        options "/L*v install.log /qn NR_LICENSE_KEY=#{license}"
 51:        action node['newrelic']['server-monitor-agent']['agent_action']
 52:        version node['newrelic']['server-monitor-agent']['windows_version']
 53:        checksum node['newrelic']['server-monitor-agent']['windows64_checksum']
 54:      end

[2014-08-18T10:39:13-04:00] ERROR: Running exception handlers
[2014-08-18T10:39:13-04:00] ERROR: Exception handlers complete
[2014-08-18T10:39:13-04:00] FATAL: Stacktrace dumped to c:/chef/cache/chef-stacktrace.out
[2014-08-18T10:39:13-04:00] INFO: Sending resource update report (run-id: 6ea27e69-fe43-4f12-9144-f6467b794099)
[2014-08-18T10:39:13-04:00] FATAL: Chef::Exceptions::CookbookNotFound: Cookbook ms_dotnet4 not found. If you're loading ms_dotnet4 from another cookbook, make sure you configure the dependency in your metadata
