### PR TITLE
.NET is not required for WIndows Server agent

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'dev@escapestudios.com'
 license 'MIT'
 description 'Installs/Configures New Relic'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.3.0'
+version '1.3.1'
 
 %w( debian ubuntu redhat centos fedora scientific amazon windows smartos ).each do |os|
   supports os

--- a/recipes/server-monitor-agent.rb
+++ b/recipes/server-monitor-agent.rb
@@ -42,7 +42,7 @@ when 'debian', 'ubuntu', 'redhat', 'centos', 'fedora', 'scientific', 'amazon', '
     action node['newrelic']['server-monitor-agent']['service_actions']
   end
 when 'windows'
- 
+
   if node['kernel']['machine'] == 'x86_64'
     windows_package 'New Relic Server Monitor' do
       source "http://download.newrelic.com/windows_server_monitor/release/NewRelicServerMonitor_x64_#{node['newrelic']['server-monitor-agent']['windows_version']}.msi"


### PR DESCRIPTION
As per closed https://github.com/escapestudios-cookbooks/newrelic/pull/114
