### PR TITLE
Move license default behavior into library

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -27,6 +27,7 @@ suites:
       - recipe[newrelic::default]
     attributes:
       newrelic:
+        license: '0000ffff0000ffff0000ffff0000ffff0000ffff'
         server_monitor_agent:
           service_notify_action: nothing
           service_actions:

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -8,10 +8,10 @@
 ##############
 # BASIC CONFIG
 ##############
-# license(s)
+# license(s), all default to node['newrelic']['license']
 default['newrelic']['license'] = nil
-default['newrelic']['server_monitoring']['license'] = node['newrelic']['license']
-default['newrelic']['application_monitoring']['license'] = node['newrelic']['license']
+default['newrelic']['server_monitoring']['license'] = nil
+default['newrelic']['application_monitoring']['license'] = nil
 
 # proxy
 default['newrelic']['proxy'] = nil

--- a/libraries/newrelic.rb
+++ b/libraries/newrelic.rb
@@ -1,0 +1,15 @@
+module Newrelic
+
+  def self.license(node)
+    node['newrelic']['license']
+  end
+
+  def self.server_monitoring_license(node)
+    node['newrelic']['server_monitoring']['license'] || license(node)
+  end
+
+  def self.application_monitoring_license(node)
+    node['newrelic']['application_monitoring']['license'] || license(node)
+  end
+
+end

--- a/recipes/dotnet_agent.rb
+++ b/recipes/dotnet_agent.rb
@@ -7,7 +7,7 @@
 
 include_recipe 'newrelic::repository'
 
-license = node['newrelic']['application_monitoring']['license']
+license = Newrelic.application_monitoring_license(node)
 
 windows_package 'Install New Relic .NET Agent' do
   source node['newrelic']['dotnet_agent']['https_download']

--- a/recipes/java_agent.rb
+++ b/recipes/java_agent.rb
@@ -7,7 +7,7 @@
 
 include_recipe 'newrelic::repository'
 
-license = node['newrelic']['application_monitoring']['license']
+license = Newrelic.application_monitoring_license(node)
 
 # create the directory to install the jar into
 directory node['newrelic']['java_agent']['install_dir'] do

--- a/recipes/nodejs_agent.rb
+++ b/recipes/nodejs_agent.rb
@@ -7,7 +7,7 @@
 
 include_recipe 'newrelic::repository'
 
-license = node['newrelic']['application_monitoring']['license']
+license = Newrelic.application_monitoring_license(node)
 
 # install the newrelic.js file into each projects
 node['newrelic']['nodejs_agent']['apps'].each do |nodeapp|

--- a/recipes/php_agent.rb
+++ b/recipes/php_agent.rb
@@ -7,7 +7,7 @@
 
 include_recipe 'newrelic::repository'
 
-license = node['newrelic']['application_monitoring']['license']
+license = Newrelic.application_monitoring_license(node)
 
 # the older version (3.0) had a bug in the init scripts that when it shut down the daemon
 # it would also kill dpkg as it was trying to upgrade let's remove the old package before continuing

--- a/recipes/python_agent.rb
+++ b/recipes/python_agent.rb
@@ -7,7 +7,7 @@
 
 include_recipe 'newrelic::repository'
 
-license = node['newrelic']['application_monitoring']['license']
+license = Newrelic.application_monitoring_license(node)
 
 python_pip 'newrelic' do
   if node['newrelic']['python_agent']['python_venv']

--- a/recipes/ruby_agent.rb
+++ b/recipes/ruby_agent.rb
@@ -7,7 +7,7 @@
 
 include_recipe 'newrelic::repository'
 
-license = node['newrelic']['application_monitoring']['license']
+license = Newrelic.application_monitoring_license(node)
 
 gem_package 'newrelic_rpm' do
   action node['newrelic']['ruby_agent']['agent_action']

--- a/recipes/server_monitor_agent.rb
+++ b/recipes/server_monitor_agent.rb
@@ -7,7 +7,7 @@
 
 include_recipe 'newrelic::repository'
 
-license = node['newrelic']['server_monitoring']['license']
+license = Newrelic.server_monitoring_license(node)
 
 case node['platform']
 when 'debian', 'ubuntu', 'redhat', 'centos', 'fedora', 'scientific', 'amazon', 'smartos'

--- a/resources/yml.rb
+++ b/resources/yml.rb
@@ -16,7 +16,7 @@ attribute :agent_type, :kind_of => String, :required => true, :regex => /^(java|
 attribute :enabled, :kind_of => [TrueClass, FalseClass, String], :default => nil
 attribute :owner, :kind_of => String, :default => nil
 attribute :group, :kind_of => String, :default => nil
-attribute :license, :kind_of => String, :default => node['newrelic']['application_monitoring']['license']
+attribute :license, :kind_of => String, :default => Newrelic.application_monitoring_license(node)
 attribute :logfile, :kind_of => String, :default => node['newrelic']['application_monitoring']['logfile']
 attribute :logfile_path, :kind_of => String, :default => node['newrelic']['application_monitoring']['logfile']
 attribute :loglevel, :kind_of => String, :default => node['newrelic']['application_monitoring']['loglevel']


### PR DESCRIPTION
Moves the handling of `['newrelic']['license']`, `['newrelic']['server_monitoring']['license']`, and `['newrelic']['application_monitoring']['license']` into a library. This defers the calculation of which value to use until the actual runtime, allowing wrapper cookbooks to set `['newrelic']['license']` and still have the value they set be usable for the other two.

This solves the complaint in https://github.com/escapestudios-cookbooks/newrelic/issues/101.

For what it's worth, you can see the successful result in the TK suite, but your tests mostly don't exist or don't seem to work, and there aren't any serverspec tests, so I didn't bother adding this to one of them.
