### PR TITLE
Add tests for new license library call

### DIFF
--- a/libraries/newrelic.rb
+++ b/libraries/newrelic.rb
@@ -1,14 +1,14 @@
 # NewRelic module
 module NewRelic
   def self.license(node)
-    node['newrelic']['license']
+    node['newrelic'] && node['newrelic']['license']
   end
 
   def self.server_monitoring_license(node)
-    node['newrelic']['server_monitoring']['license'] || license(node)
+    node['newrelic'] && node['newrelic']['server_monitoring'] && node['newrelic']['server_monitoring']['license'] || license(node)
   end
 
   def self.application_monitoring_license(node)
-    node['newrelic']['application_monitoring']['license'] || license(node)
+    node['newrelic'] && node['newrelic']['application_monitoring'] && node['newrelic']['application_monitoring']['license'] || license(node)
   end
 end

--- a/spec/unit/license_spec.rb
+++ b/spec/unit/license_spec.rb
@@ -1,0 +1,66 @@
+require 'spec_helper'
+require_relative '../../libraries/newrelic'
+
+describe 'libraries/newrelic.rb' do
+
+  # helper to build different kinds of node objects
+  def build_node(lic = nil, server = nil, app = nil)
+    node = {}
+    node['newrelic'] = {}
+
+    if lic
+      node['newrelic']['license'] = lic
+    end
+
+    if server
+      node['newrelic']['server_monitoring'] = {}
+      node['newrelic']['server_monitoring']['license'] = server
+    end
+
+    if app
+      node['newrelic']['application_monitoring'] = {}
+      node['newrelic']['application_monitoring']['license'] = app
+    end
+
+    node
+  end
+
+  it "returns nil when node['newrelic'] is not defined" do
+    license = NewRelic.license({})
+    expect(license).to be(nil)
+  end
+
+  it "returns nil when node['newrelic']['license'] is not defined" do
+    license = NewRelic.license(build_node)
+    expect(license).to be(nil)
+  end
+
+  it "returns node['newrelic']['license'] for all licenses when main value is set" do
+    node = build_node(lic = 'a')
+    expect(NewRelic.license(node)).to eq('a')
+    expect(NewRelic.server_monitoring_license(node)).to eq('a')
+    expect(NewRelic.application_monitoring_license(node)).to eq('a')
+  end
+
+  it "returns node['newrelic']['license'] for all licenses except node['newrelic']['server_monitoring']['license']" do
+    node = build_node(lic = 'a', server = 'b', app = nil)
+    expect(NewRelic.license(node)).to eq('a')
+    expect(NewRelic.server_monitoring_license(node)).to eq('b')
+    expect(NewRelic.application_monitoring_license(node)).to eq('a')
+  end
+
+  it "returns node['newrelic']['license'] for all licenses except node['newrelic']['application_monitoring']['license']" do
+    node = build_node(lic = 'a', server = nil, app = 'c')
+    expect(NewRelic.license(node)).to eq('a')
+    expect(NewRelic.server_monitoring_license(node)).to eq('a')
+    expect(NewRelic.application_monitoring_license(node)).to eq('c')
+  end
+
+  it "returns unique node['newrelic']['license'], node['newrelic']['server_monitoring']['license'], and node['newrelic']['application_monitoring']['license']" do
+    node = build_node(lic = 'a', server = 'b', app = 'c')
+    expect(NewRelic.license(node)).to eq('a')
+    expect(NewRelic.server_monitoring_license(node)).to eq('b')
+    expect(NewRelic.application_monitoring_license(node)).to eq('c')
+  end
+
+end


### PR DESCRIPTION
As requested in https://github.com/escapestudios-cookbooks/newrelic/pull/139#issuecomment-63174882, here are some tests for the library call that determines licenses. I've also made a modification to the call itself, so it returns an appropriate value (`nil`) if `node['newrelic']` is not defined.
