### PR TITLE
'recommends' not recommended for Berkshelf users

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -11,8 +11,7 @@ version '2.5.2'
 end
 
 depends 'python'
-
-recommends 'curl'
+depends 'curl'
 
 recipe 'newrelic', 'Adds the New Relic repository, installs & configures the New Relic server monitor agent.'
 recipe 'newrelic::repository', 'Adds the New Relic repository.'


### PR DESCRIPTION
Due to https://github.com/berkshelf/berkshelf/issues/1362 and https://github.com/berkshelf/berkshelf/issues/1216, many users are reporting bugs with missing `curl` cookbooks upstream to cookbooks I maintain; I also encounter the bug. The problem is that `depends` should be used over `recommends` if the cookbook cannot perform all functions without the dependency.

See https://docs.chef.io/config_rb_metadata.html:

> Adds a dependency on another cookbook that is recommended, but not required. A cookbook will still work even if recommended dependencies are not available.

Parts of the newrelic cookbook simply do not work without the `curl` cookbook.