### PR TITLE
Enable the thread profiler based on attributes.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ group :unit, :integration do
 end
 
 group :unit do
-  gem 'chefspec', '~> 3.1'
+  gem 'chefspec', '~> 3.4'
   gem 'rspec-expectations', '~> 2.14.0'
 end
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Attributes
 * `node['newrelic']['application_monitoring']['webtransaction']['name']['functions']`
 * `node['newrelic']['application_monitoring']['webtransaction']['name']['files']`
 * `node['newrelic']['application_monitoring']['cross_application_tracer']['enable']` - Implemented for Java, PHP, Python and Ruby
+* `node['newrelic']['application_monitoring']['thread_profiler']['enable']` - Implemented for Java, Python and Ruby
 
 ## repository.rb:
 * `node['newrelic']['repository']['repository_key']` - The New Relic repository key, defaults to "548C16BF"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -51,6 +51,7 @@ default['newrelic']['application_monitoring']['daemon']['collector_host'] = nil
 default['newrelic']['application_monitoring']['daemon']['dont_launch'] = nil
 default['newrelic']['application_monitoring']['capture_params'] = nil
 default['newrelic']['application_monitoring']['cross_application_tracer']['enable'] = nil
+default['newrelic']['application_monitoring']['thread_profiler']['enable'] = nil
 default['newrelic']['application_monitoring']['ignored_params'] = nil
 default['newrelic']['application_monitoring']['error_collector']['enable'] = nil
 default['newrelic']['application_monitoring']['error_collector']['ignore_errors'] = nil

--- a/providers/yml.rb
+++ b/providers/yml.rb
@@ -63,7 +63,8 @@ action :generate do
       :error_collector_ignore_errors => new_resource.error_collector_ignore_errors,
       :error_collector_ignore_status_codes => new_resource.error_collector_ignore_status_codes,
       :browser_monitoring_auto_instrument => new_resource.browser_monitoring_auto_instrument,
-      :cross_application_tracer_enable => new_resource.cross_application_tracer_enable
+      :cross_application_tracer_enable => new_resource.cross_application_tracer_enable,
+      :thread_profiler_enable => new_resource.thread_profiler_enable
     )
     action :create
   end

--- a/recipes/java_agent.rb
+++ b/recipes/java_agent.rb
@@ -66,6 +66,7 @@ newrelic_yml "#{node['newrelic']['java_agent']['install_dir']}/newrelic.yml" do
   error_collector_ignore_status_codes node['newrelic']['application_monitoring']['error_collector']['ignore_status_codes']
   browser_monitoring_auto_instrument node['newrelic']['application_monitoring']['browser_monitoring']['auto_instrument']
   cross_application_tracer_enable node['newrelic']['application_monitoring']['cross_application_tracer']['enable']
+  thread_profiler_enable node['newrelic']['application_monitoring']['thread_profiler']['enable']
 end
 
 # allow app_group to write to log_file_path

--- a/recipes/python_agent.rb
+++ b/recipes/python_agent.rb
@@ -45,7 +45,8 @@ template node['newrelic']['python_agent']['config_file'] do
     :error_collector_ignore_errors => node['newrelic']['application_monitoring']['error_collector']['ignore_errors'],
     :browser_monitoring_auto_instrument => node['newrelic']['application_monitoring']['browser_monitoring']['auto_instrument'],
     :cross_application_tracer_enable => node['newrelic']['application_monitoring']['cross_application_tracer']['enable'],
-    :feature_flag => node['newrelic']['python_agent']['feature_flag']
+    :feature_flag => node['newrelic']['python_agent']['feature_flag'],
+    :thread_profiler_enable => node['newrelic']['application_monitoring']['thread_profiler']['enable']
   )
   action :create
 end

--- a/recipes/ruby_agent.rb
+++ b/recipes/ruby_agent.rb
@@ -49,4 +49,5 @@ newrelic_yml "#{node['newrelic']['ruby_agent']['install_dir']}/newrelic.yml" do
   error_collector_ignore_status_codes node['newrelic']['application_monitoring']['error_collector']['ignore_status_codes']
   browser_monitoring_auto_instrument node['newrelic']['application_monitoring']['browser_monitoring']['auto_instrument']
   cross_application_tracer_enable node['newrelic']['application_monitoring']['cross_application_tracer']['enable']
+  thread_profiler_enable node['newrelic']['application_monitoring']['thread_profiler']['enable']
 end

--- a/resources/yml.rb
+++ b/resources/yml.rb
@@ -39,3 +39,4 @@ attribute :error_collector_ignore_errors, :default => node['newrelic']['applicat
 attribute :error_collector_ignore_status_codes, :default => node['newrelic']['application_monitoring']['error_collector']['ignore_status_codes']
 attribute :browser_monitoring_auto_instrument, :default => node['newrelic']['application_monitoring']['browser_monitoring']['auto_instrument']
 attribute :cross_application_tracer_enable, :default => node['newrelic']['application_monitoring']['browser_monitoring']['auto_instrument']
+attribute :thread_profiler_enable, :default => node['newrelic']['application_monitoring']['thread_profiler']['enable']

--- a/templates/default/agent/newrelic.yml.erb
+++ b/templates/default/agent/newrelic.yml.erb
@@ -306,7 +306,11 @@ common: &default_settings
 
     # Set to false to disable the thread profiler.
     # Default is true.
+    <% if @thread_profiler_enable.nil? %>
     enabled: true
+    <% else %>
+    enabled: <%= @thread_profiler_enable %>
+    <% end %>
 
   #============================== Browser Monitoring ===============================
   # New Relic Real User Monitoring gives you insight into the performance real users are

--- a/templates/default/agent/python/newrelic.ini.erb
+++ b/templates/default/agent/python/newrelic.ini.erb
@@ -232,7 +232,11 @@ browser_monitoring.auto_instrument = <%= @browser_monitoring_auto_instrument %>
 # capture a snapshot of the call stack for each active thread in
 # the application to construct a statistically representative
 # call tree.
+<% if @thread_profiler_enable.nil? %>
 thread_profiler.enabled = true
+<% else %>
+thread_profiler.enabled = <%= @thread_profiler_enable %>
+<% end %>
 
 # Enable or disable the cross application tracer.
 # The cross application tracer inserts HTTP headers into outbound requests


### PR DESCRIPTION
I need to be able to disable the thread profiler. It was hard-coded in templates; with this change, the enabled/disabled value is taken from attributes.

FYI, had to upgrade chefspec to 3.4 to get the `do_nothing` feature to fix a failing test from an unrelated change.