### PR TITLE
Use yum & apt LWRPs to set up New Relic repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Make sure you run Chef >= 0.10.0.
 
 * python
 * curl
+* apt
+* yum
 
 ### Platforms:
 
@@ -106,10 +108,9 @@ Make sure you run Chef >= 0.10.0.
 
 ### repository.rb:
 
-* `node['newrelic']['repository']['repository_key']` - The New Relic repository key, defaults to "548C16BF"
-* `node['newrelic']['repository']['repository_action']` - Repository action, defaults to :install
+* `node['newrelic']['repo']['repo_key']` - URL to the New Relic repository key, defaults to "http://download.newrelic.com/548C16BF.gpg"
 
-### php_agent.rb:
+* ### php_agent.rb:
 
 * `node['newrelic']['php_agent']['agent_action']` - Agent action, defaults to :install
 * `node['newrelic']['php_agent']['install_silently']` - Determine whether to run the install in silent mode, defaults to false

--- a/attributes/repository.rb
+++ b/attributes/repository.rb
@@ -5,5 +5,13 @@
 # Copyright 2012-2014, Escape Studios
 #
 
-default['newrelic']['repository']['repository_key'] = '548C16BF'
-default['newrelic']['repository']['repository_action'] = :install
+default['newrelic']['repo']['key'] = 'http://download.newrelic.com/548C16BF.gpg'
+
+case node['platform_family']
+when 'debian'
+  default['newrelic']['repo']['uri'] = 'http://download.newrelic.com/debian/'
+  default['newrelic']['repo']['distribution'] = 'newrelic'
+  default['newrelic']['repo']['components'] = ['non-free']
+when 'rhel'
+  default['newrelic']['repo']['uri'] = 'http://download.newrelic.com/pub/newrelic/el5/$basearch/'
+end

--- a/metadata.rb
+++ b/metadata.rb
@@ -12,6 +12,8 @@ end
 
 depends 'python'
 depends 'curl'
+depends 'apt', '~> 2.0'
+depends 'yum', '~> 3.0'
 
 recipe 'newrelic', 'Adds the New Relic repository, installs & configures the New Relic server monitor agent.'
 recipe 'newrelic::repository', 'Adds the New Relic repository.'

--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -5,59 +5,18 @@
 # Copyright 2012-2014, Escape Studios
 #
 
-case node['platform']
-when 'debian', 'ubuntu', 'redhat', 'centos', 'fedora', 'scientific', 'amazon', 'oracle'
-  package 'wget'
-end
-
-case node['platform']
-when 'debian', 'ubuntu'
-  # trust the New Relic GPG Key
-  # this step is required to tell apt that you trust the integrity of New Relic's apt repository
-  gpg_key_url = "http://download.newrelic.com/#{node['newrelic']['repository']['repository_key']}.gpg"
-  gpg_key_file = "#{Chef::Config[:file_cache_path]}/#{node['newrelic']['repository']['repository_key']}.gpg"
-
-  remote_file gpg_key_file do
-    source gpg_key_url
-    action :create
-    notifies :run, 'execute[newrelic-add-apt-key]', :immediately
+case node['platform_family']
+when 'debian'
+  apt_repository 'newrelic' do
+    uri node['newrelic']['repo']['uri']
+    distribution node['newrelic']['repo']['distribution']
+    components node['newrelic']['repo']['components']
+    key node['newrelic']['repo']['key']
   end
-
-  execute 'newrelic-add-apt-key' do
-    command "apt-key add #{gpg_key_file}"
-    action :nothing
-  end
-
-  # configure the New Relic apt repository
-  remote_file '/etc/apt/sources.list.d/newrelic.list' do
-    source 'http://download.newrelic.com/debian/newrelic.list'
-    owner 'root'
-    group 'root'
-    mode 0644
-    notifies :run, 'execute[newrelic-apt-get-update]', :immediately
-    action :create_if_missing
-  end
-
-  execute 'newrelic-apt-get-update' do
-    command 'apt-get update'
-    action :nothing
-  end
-when 'redhat', 'centos', 'fedora', 'scientific', 'amazon', 'oracle'
-  # install the newrelic-repo package, which configures a new package repository for yum
-  if node['kernel']['machine'] == 'x86_64'
-    machine = 'x86_64'
-  else
-    machine = 'i386'
-  end
-
-  remote_file "#{Chef::Config[:file_cache_path]}/newrelic-repo-5-3.noarch.rpm" do
-    source "http://download.newrelic.com/pub/newrelic/el5/#{machine}/newrelic-repo-5-3.noarch.rpm"
-    action :create_if_missing
-  end
-
-  package 'newrelic-repo' do
-    source "#{Chef::Config[:file_cache_path]}/newrelic-repo-5-3.noarch.rpm"
-    provider Chef::Provider::Package::Rpm
-    action node['newrelic']['repository']['repository_action']
+when 'rhel'
+  yum_repository 'newrelic' do
+    description 'New Relic packages for Enterprise Linux 5 - $basearch'
+    baseurl node['newrelic']['repo']['uri']
+    gpgkey node['newrelic']['repo']['key']
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,8 @@ require 'chefspec/berkshelf'
 
 RSpec.configure do |config|
   config.log_level = :error
+  config.formatter = :documentation
+  config.color     = true
 end
 
 at_exit { ChefSpec::Coverage.report! }

--- a/spec/unit/repository_spec.rb
+++ b/spec/unit/repository_spec.rb
@@ -1,65 +1,57 @@
 require 'spec_helper'
 
 describe 'newrelic::repository' do
-  before(:each) do
-    stub_command('apt-key list | grep 548C16BF').and_return(true)
-  end
+  # before(:each) do
+  #   stub_command('apt-key list | grep 548C16BF').and_return(true)
+  # end
 
   context 'Ubuntu 12.04' do
     let(:chef_run) { ChefSpec::Runner.new(:platform => 'ubuntu', :version => '12.04').converge(described_recipe) }
 
-    it 'downloads the gpg key file' do
-      expect(chef_run).to create_remote_file("#{Chef::Config[:file_cache_path]}/#{chef_run.node['newrelic']['repository']['repository_key']}.gpg")
-    end
-
-    it 'downloads the newrelic sources file' do
-      expect(chef_run).to create_remote_file_if_missing('/etc/apt/sources.list.d/newrelic.list')
-    end
-
-    it 'runs "apt-get update"' do
-      resource = chef_run.remote_file('/etc/apt/sources.list.d/newrelic.list')
-      expect(resource).to notify 'execute[apt-get update]'
+    it 'installs the New Relic apt repository' do
+      expect(chef_run).to add_apt_repository('newrelic').with(
+        :uri          => 'http://download.newrelic.com/debian/',
+        :distribution => 'newrelic',
+        :components   => ['non-free'],
+        :key          => 'http://download.newrelic.com/548C16BF.gpg'
+      )
     end
   end
 
   context 'Debian 7' do
     let(:chef_run) { ChefSpec::Runner.new(:platform => 'debian', :version => '7.1').converge(described_recipe) }
 
-    it 'downloads the gpg key file' do
-      expect(chef_run).to create_remote_file("#{Chef::Config[:file_cache_path]}/#{chef_run.node['newrelic']['repository']['repository_key']}.gpg")
-    end
-
-    it 'downloads the newrelic sources file' do
-      expect(chef_run).to create_remote_file_if_missing('/etc/apt/sources.list.d/newrelic.list')
-    end
-
-    it 'runs "apt-get update"' do
-      resource = chef_run.remote_file('/etc/apt/sources.list.d/newrelic.list')
-      expect(resource).to notify 'execute[apt-get update]'
+    it 'installs the New Relic apt repository' do
+      expect(chef_run).to add_apt_repository('newrelic').with(
+        :uri          => 'http://download.newrelic.com/debian/',
+        :distribution => 'newrelic',
+        :components   => ['non-free'],
+        :key          => 'http://download.newrelic.com/548C16BF.gpg'
+      )
     end
   end
 
   context 'CentOS 6' do
     let(:chef_run) { ChefSpec::Runner.new(:platform => 'centos', :version => '6.4').converge(described_recipe) }
 
-    it 'downloads the newrelic rpm' do
-      expect(chef_run).to create_remote_file_if_missing(Chef::Config[:file_cache_path] + '/newrelic-repo-5-3.noarch.rpm')
-    end
-
-    it 'installs the "newrelic-repo" package' do
-      expect(chef_run).to install_package('newrelic-repo')
+    it 'installs the New Relic yum repository' do
+      expect(chef_run).to create_yum_repository('newrelic').with(
+        :description => 'New Relic packages for Enterprise Linux 5 - $basearch',
+        :baseurl => 'http://download.newrelic.com/pub/newrelic/el5/$basearch/',
+        :gpgkey => 'http://download.newrelic.com/548C16BF.gpg'
+      )
     end
   end
 
   context 'RedHat 6' do
     let(:chef_run) { ChefSpec::Runner.new(:platform => 'redhat', :version => '6.3').converge(described_recipe) }
 
-    it 'downloads the newrelic rpm' do
-      expect(chef_run).to create_remote_file_if_missing(Chef::Config[:file_cache_path] + '/newrelic-repo-5-3.noarch.rpm')
-    end
-
-    it 'installs the "newrelic-repo" package' do
-      expect(chef_run).to install_package('newrelic-repo')
+    it 'installs the New Relic yum repository' do
+      expect(chef_run).to create_yum_repository('newrelic').with(
+        :description => 'New Relic packages for Enterprise Linux 5 - $basearch',
+        :baseurl => 'http://download.newrelic.com/pub/newrelic/el5/$basearch/',
+        :gpgkey => 'http://download.newrelic.com/548C16BF.gpg'
+      )
     end
   end
 end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe 'newrelic::default' do
+  describe yumrepo('newrelic'), :if => os[:family] == 'redhat' do
+    it { is_expected.to exist }
+    it { is_expected.to be_enabled }
+  end
+
+  describe file('/etc/apt/sources.list.d/newrelic.list'), :if => %w(debian ubuntu).include?(os[:family]) do
+    it { is_expected.to be_file }
+  end
+
+  describe package 'newrelic-sysmond' do
+    it { is_expected.to be_installed }
+  end
+end

--- a/test/integration/default/serverspec/spec_helper.rb
+++ b/test/integration/default/serverspec/spec_helper.rb
@@ -1,0 +1,3 @@
+require 'serverspec'
+
+set :backend, :exec


### PR DESCRIPTION
A rebase & update of #63

Closes #63

Rather than manually setting up the distro-appropriate repo for installing the NR packages, we can take advantage of the various community cookbooks to install repos, providing a much cleaner, and more idempotent, way to manage these repos.