### PR TITLE
Adds newrelic::php_agent web_server server_action attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ newrelic cookbook CHANGELOG
 ===========================
 This file is used to list changes made in each version (> 2.0.0) of the newrelic cookbook.
 
+- Allow php_agent's web_server service_name action to be specified enabling graceful restarts eg. php-fpm
+- Fixed Chefspec example for php_agent notifying newrelic-daemon to restart immediately
+
 v2.0.0 (2014-07-02)
 -------------------
 - Refactoring: separation of New Relic MeetMe plugin logic into separate cookbook: https://github.com/escapestudios-cookbooks/newrelic_meetme_plugin

--- a/Gemfile
+++ b/Gemfile
@@ -20,4 +20,5 @@ group :integration do
   gem 'test-kitchen', '~> 1.2'
   gem 'kitchen-vagrant', '~> 0.11'
   gem 'serverspec', '~> 1.0'
+  gem 'vagrant-wrapper', '~> 2.0.2'
 end

--- a/attributes/php_agent.rb
+++ b/attributes/php_agent.rb
@@ -9,6 +9,7 @@ default['newrelic']['php_agent']['agent_action'] = :install
 default['newrelic']['php_agent']['install_silently'] = false
 default['newrelic']['php_agent']['startup_mode'] = 'agent'
 default['newrelic']['php_agent']['web_server']['service_name'] = 'apache2'
+default['newrelic']['php_agent']['web_server']['service_action'] = 'restart'
 default['newrelic']['php_agent']['config_file'] = nil
 default['newrelic']['php_agent']['config_file_to_be_deleted'] = nil
 default['newrelic']['php_agent']['execute_php5enmod'] = false

--- a/recipes/php_agent.rb
+++ b/recipes/php_agent.rb
@@ -35,7 +35,7 @@ execute 'newrelic-install' do
   end
   action :nothing
   if node['newrelic']['php_agent']['web_server']['service_name']
-    notifies :reload, "service[#{node['newrelic']['php_agent']['web_server']['service_name']}]", :delayed
+    notifies node['newrelic']['php_agent']['web_server']['service_action'].to_sym, "service[#{node['newrelic']['php_agent']['web_server']['service_name']}]", :delayed
   end
 end
 
@@ -107,7 +107,7 @@ template node['newrelic']['php_agent']['config_file'] do
     notifies :run, 'execute[newrelic-php5enmod]', :immediately
   end
   if node['newrelic']['php_agent']['web_server']['service_name']
-    notifies :restart, "service[#{node['newrelic']['php_agent']['web_server']['service_name']}]", :delayed
+    notifies node['newrelic']['php_agent']['web_server']['service_action'].to_sym, "service[#{node['newrelic']['php_agent']['web_server']['service_name']}]", :delayed
   end
 end
 
@@ -171,7 +171,7 @@ when 'external'
     action :create
     notifies :restart, 'service[newrelic-daemon]', :immediately
     if node['newrelic']['php_agent']['web_server']['service_name']
-      notifies :restart, "service[#{node['newrelic']['php_agent']['web_server']['service_name']}]", :delayed
+      notifies node['newrelic']['php_agent']['web_server']['service_action'].to_sym, "service[#{node['newrelic']['php_agent']['web_server']['service_name']}]", :delayed
     end
   end
 

--- a/spec/unit/php_agent_spec.rb
+++ b/spec/unit/php_agent_spec.rb
@@ -32,8 +32,9 @@ describe 'newrelic::php_agent' do
       expect(chef_run.execute('newrelic-install')).to do_nothing
     end
 
-    it 'restarts the webserver at the end of the chef run when running newrelic-install' do
-      expect(chef_run.execute('newrelic-install')).to notify("service[#{chef_run.node['newrelic']['php_agent']['web_server']['service_name']}]").delayed
+    it 'notifies the webserver at the end of the chef run when running newrelic-install' do
+      expect(chef_run.execute('newrelic-install')).to notify("service[#{chef_run.node['newrelic']['php_agent']['web_server']['service_name']}]").to(
+        chef_run.node['newrelic']['php_agent']['web_server']['service_action'].to_sym).delayed
     end
 
     it 'creates newrelic ini config template from newrelic.ini.erb' do
@@ -45,7 +46,8 @@ describe 'newrelic::php_agent' do
     end
 
     it 'restarts the webserver at the end of the chef run when changing the config file' do
-      expect(chef_run.template("#{chef_run.node['newrelic']['php_agent']['config_file']}")).to notify("service[#{chef_run.node['newrelic']['php_agent']['web_server']['service_name']}]").delayed
+      expect(chef_run.template("#{chef_run.node['newrelic']['php_agent']['config_file']}")).to notify("service[#{chef_run.node['newrelic']['php_agent']['web_server']['service_name']}]").to(
+        chef_run.node['newrelic']['php_agent']['web_server']['service_action'].to_sym).delayed
     end
 
     it 'logs the startup mode' do
@@ -68,11 +70,12 @@ describe 'newrelic::php_agent' do
       end
 
       it 'restarts the webserver at the end of the chef run when changing /etc/newrelic/newrelic.cfg config file' do
-        expect(chef_run.template('/etc/newrelic/newrelic.cfg')).to notify("service[#{chef_run.node['newrelic']['php_agent']['web_server']['service_name']}]").delayed
+        expect(chef_run.template('/etc/newrelic/newrelic.cfg')).to notify("service[#{chef_run.node['newrelic']['php_agent']['web_server']['service_name']}]").to(
+          chef_run.node['newrelic']['php_agent']['web_server']['service_action'].to_sym).delayed
       end
 
       it 'restarts the newrelic-daemon when changing /etc/newrelic/newrelic.cfg config file' do
-        expect(chef_run.template('/etc/newrelic/newrelic.cfg')).to notify("service[#{chef_run.node['newrelic']['php_agent']['web_server']['service_name']}]").delayed
+        expect(chef_run.template('/etc/newrelic/newrelic.cfg')).to notify('service[newrelic-daemon]').immediately
       end
 
       it 'starts and enables newrelic-daemon' do


### PR DESCRIPTION
* Add node['newrelic']['php_agent']['web_server']['service_action']
 * defaults to 'restart' as service_name is apache2
 * allows php-fpm to be gracefully reloaded and not drop requests
 * each resource notifying service[service_name] updated
 * updated Chefspec tests
* Fixed Chefspec example for php_agent notifying newrelic-daemon to restart immediately