### PR TITLE
Support for labels in Java and Ruby agents

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -53,6 +53,7 @@ default['newrelic']['application_monitoring']['daemon']['dont_launch'] = nil
 default['newrelic']['application_monitoring']['capture_params'] = nil
 default['newrelic']['application_monitoring']['cross_application_tracer']['enable'] = nil
 default['newrelic']['application_monitoring']['thread_profiler']['enable'] = nil
+default['newrelic']['application_monitoring']['labels'] = nil
 default['newrelic']['application_monitoring']['ignored_params'] = nil
 default['newrelic']['application_monitoring']['error_collector']['enable'] = nil
 default['newrelic']['application_monitoring']['error_collector']['ignore_errors'] = nil

--- a/providers/yml.rb
+++ b/providers/yml.rb
@@ -65,7 +65,8 @@ action :generate do
       :error_collector_ignore_status_codes => new_resource.error_collector_ignore_status_codes,
       :browser_monitoring_auto_instrument => new_resource.browser_monitoring_auto_instrument,
       :cross_application_tracer_enable => new_resource.cross_application_tracer_enable,
-      :thread_profiler_enable => new_resource.thread_profiler_enable
+      :thread_profiler_enable => new_resource.thread_profiler_enable,
+      :labels => new_resource.labels
     )
     action :create
   end

--- a/recipes/java_agent.rb
+++ b/recipes/java_agent.rb
@@ -66,6 +66,7 @@ newrelic_yml "#{node['newrelic']['java_agent']['install_dir']}/newrelic.yml" do
   browser_monitoring_auto_instrument node['newrelic']['application_monitoring']['browser_monitoring']['auto_instrument']
   cross_application_tracer_enable node['newrelic']['application_monitoring']['cross_application_tracer']['enable']
   thread_profiler_enable node['newrelic']['application_monitoring']['thread_profiler']['enable']
+  labels node['newrelic']['application_monitoring']['labels']
 end
 
 # allow app_group to write to log_file_path

--- a/recipes/ruby_agent.rb
+++ b/recipes/ruby_agent.rb
@@ -51,4 +51,5 @@ newrelic_yml "#{node['newrelic']['ruby_agent']['install_dir']}/newrelic.yml" do
   browser_monitoring_auto_instrument node['newrelic']['application_monitoring']['browser_monitoring']['auto_instrument']
   cross_application_tracer_enable node['newrelic']['application_monitoring']['cross_application_tracer']['enable']
   thread_profiler_enable node['newrelic']['application_monitoring']['thread_profiler']['enable']
+  labels node['newrelic']['application_monitoring']['labels']
 end

--- a/resources/yml.rb
+++ b/resources/yml.rb
@@ -41,3 +41,4 @@ attribute :error_collector_ignore_status_codes, :default => node['newrelic']['ap
 attribute :browser_monitoring_auto_instrument, :default => node['newrelic']['application_monitoring']['browser_monitoring']['auto_instrument']
 attribute :cross_application_tracer_enable, :default => node['newrelic']['application_monitoring']['browser_monitoring']['auto_instrument']
 attribute :thread_profiler_enable, :default => node['newrelic']['application_monitoring']['thread_profiler']['enable']
+attribute :labels, :default => node['newrelic']['application_monitoring']['labels']

--- a/templates/default/agent/newrelic.yml.erb
+++ b/templates/default/agent/newrelic.yml.erb
@@ -319,6 +319,15 @@ common: &default_settings
     enabled: <%= @thread_profiler_enable %>
     <% end %>
 
+  # A dictionary of label names and values that will be applied to the data sent from
+  # this agent. May also be expressed as a semi-colon delimited string of colon-separated
+  # pairs for example, Server:One;Data Center:Primary).  
+  <% if @labels.nil? %>
+  #labels:
+  <% else %>
+  labels: <%= @labels %>
+  <% end %>
+
   #============================== Browser Monitoring ===============================
   # New Relic Real User Monitoring gives you insight into the performance real users are
   # experiencing with your website. This is accomplished by measuring the time it takes for


### PR DESCRIPTION
Adds support for application labels when using Java and Ruby agents (those that utilize newrelic.yml).