### PR TITLE
Add source and issues URLs to metadata for Supermarket

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -5,6 +5,8 @@ license 'MIT'
 description 'Installs/Configures New Relic'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '2.11.0'
+source_url 'https://github.com/escapestudios-cookbooks/newrelic'
+issues_url 'https://github.com/escapestudios-cookbooks/newrelic/issues'
 
 %w( debian ubuntu redhat centos fedora scientific amazon windows smartos oracle ).each do |os|
   supports os


### PR DESCRIPTION
Makes it simpler to get from the Supermarket to the GitHub repo.