### PR TITLE
Adjust boolean/string logic

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -19,7 +19,7 @@ platforms:
       - recipe[apt]
     attributes:
       newrelic:
-        php5enmode: = true
+        php5enmode: 'true'
         php_agent:
           web_server:
             service_name: apache2
@@ -45,13 +45,13 @@ suites:
           service_actions:
             - nothing
   - name: php-agent
-    run_list: 
+    run_list:
       - "recipe[newrelic_lwrp_test::agent_php]"
-    attributes: 
-      newrelic: 
+    attributes:
+      newrelic:
         license: '0000ffff0000ffff0000ffff0000ffff0000ffff'
   - name: server-monitor
     run_list: "recipe[newrelic_lwrp_test::server_monitor]"
-    attributes: 
-      newrelic: 
+    attributes:
+      newrelic:
         license: '0000ffff0000ffff0000ffff0000ffff0000ffff'

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -8,7 +8,7 @@ module NewRelic
 
     def check_license
       # check license key provided
-      fail 'The NewRelic key is required to notify New Relic of a deployment.' if new_resource.license.nil?
+      fail 'The NewRelic key is required to notify New Relic of a deployment.' unless new_resource.license && !new_resource.license.empty?
     end
 
     def install_newrelic_repo
@@ -32,14 +32,6 @@ module NewRelic
         description 'New Relic packages for Enterprise Linux 5 - $basearch'
         baseurl node['newrelic']['repository']['uri']
         gpgkey node['newrelic']['repository']['key']
-      end
-    end
-
-    def to_boolean(variable)
-      if variable.is_a?(TrueClass) || variable.is_a?(FalseClass)
-        variable
-      else
-        variable == 'true' || variable == 1
       end
     end
   end

--- a/libraries/newrelic.rb
+++ b/libraries/newrelic.rb
@@ -11,4 +11,16 @@ module NewRelic
   def self.application_monitoring_license(node)
     node['newrelic'] && node['newrelic']['application_monitoring'] && node['newrelic']['application_monitoring']['license'] || license(node)
   end
+
+  def self.to_string_from_boolean(variable)
+    if variable.nil?
+      nil
+    elsif variable.is_a?(TrueClass)
+      'true'
+    elsif variable.is_a?(FalseClass)
+      'false'
+    else
+      variable
+    end
+  end
 end

--- a/providers/deployment.rb
+++ b/providers/deployment.rb
@@ -15,12 +15,12 @@ action :notify do
   key = new_resource.key
 
   # @todo take out deprecated api_key logic
-  unless new_resource.api_key.nil?
+  if new_resource.api_key && !new_resource.api_key.empty?
     Chef::Log.warn "The 'api_key'-attribute has been deprecated. Please make use of the key and key_type attributes instead."
     key = new_resource.api_key
   end
 
-  if key.nil?
+  unless key && !key.empty?
     Chef::Log.fatal "The #{key_type} is required to notify New Relic of a deployment."
   end
 
@@ -35,27 +35,27 @@ action :notify do
       data << '"x-api-key:' + key + '"'
     end
 
-    unless new_resource.app_name.nil?
+    if new_resource.app_name && !new_resource.app_name.empty?
       data << '-d "deployment[app_name]=' + new_resource.app_name + '"'
     end
 
-    unless new_resource.app_id.nil?
+    if new_resource.app_id && !new_resource.app_id.empty?
       data << '-d "deployment[app_id]=' + new_resource.app_id.to_s + '"'
     end
 
-    unless new_resource.description.nil?
+    if new_resource.description && !new_resource.description.empty?
       data << '-d "deployment[description]=' + clean(new_resource.description) + '"'
     end
 
-    unless new_resource.revision.nil?
+    if new_resource.revision && !new_resource.revision.empty?
       data << '-d "deployment[revision]=' + new_resource.revision + '"'
     end
 
-    unless new_resource.changelog.nil?
+    if new_resource.changelog && !new_resource.changelog.empty?
       data << '-d "deployment[changelog]=' + clean(new_resource.changelog) + '"'
     end
 
-    unless new_resource.user.nil?
+    if new_resource.user && !new_resource.user.empty?
       data << '-d "deployment[user]=' + new_resource.user + '"'
     end
 

--- a/providers/yml.rb
+++ b/providers/yml.rb
@@ -14,18 +14,18 @@ def whyrun_supported?
 end
 
 action :generate do
-  if new_resource.daemon_proxy.nil?
-    daemon_proxy_host = nil
-    daemon_proxy_port = nil
-    daemon_proxy_user = nil
-    daemon_proxy_password = nil
-  else
+  if new_resource.daemon_proxy && !new_resource.daemon_proxy.empty?
     proxy = URI(new_resource.daemon_proxy)
 
     daemon_proxy_host = proxy.host
     daemon_proxy_port = proxy.port
     daemon_proxy_user = proxy.user
     daemon_proxy_password = proxy.password
+  else
+    daemon_proxy_host = nil
+    daemon_proxy_port = nil
+    daemon_proxy_user = nil
+    daemon_proxy_password = nil
   end
 
   t = template new_resource.yml_path do

--- a/recipes/java_agent.rb
+++ b/recipes/java_agent.rb
@@ -28,7 +28,7 @@ remote_file agent_jar do
   action :create_if_missing
 end
 
-if node['newrelic']['application_monitoring']['app_name'].nil?
+unless node['newrelic']['application_monitoring']['app_name'] && !node['newrelic']['application_monitoring']['app_name'].empty?
   node.set['newrelic']['application_monitoring']['app_name'] = node['hostname']
 end
 

--- a/recipes/php_agent.rb
+++ b/recipes/php_agent.rb
@@ -7,50 +7,50 @@
 
 newrelic_agent_php 'Install' do
   license NewRelic.application_monitoring_license(node)
-  config_file node['newrelic']['php_agent']['config_file'] unless node['newrelic']['php_agent']['config_file'].nil?
-  startup_mode node['newrelic']['php_agent']['startup_mode'] unless node['newrelic']['php_agent']['startup_mode'].nil?
-  app_name node['newrelic']['application_monitoring']['app_name'] unless node['newrelic']['application_monitoring']['app_name'].nil?
-  high_security NewRelic.to_boolean(node['newrelic']['application_monitoring']['high_security']) unless node['newrelic']['application_monitoring']['high_security'].nil?
-  install_silently node['newrelic']['php_agent']['install_silently'] unless node['newrelic']['php_agent']['install_silently'].nil?
-  config_file_to_be_deleted node['newrelic']['php_agent']['config_file_to_be_deleted'] unless node['newrelic']['php_agent']['config_file_to_be_deleted'].nil?
-  service_name node['newrelic']['php_agent']['web_server']['service_name'] unless node['newrelic']['php_agent']['web_server']['service_name'].nil?
-  execute_php5enmod NewRelic.to_boolean(node['newrelic']['php_agent']['execute_php5enmod']) unless node['newrelic']['php_agent']['execute_php5enmod'].nil?
-  cookbook_ini node['newrelic']['php_agent']['template']['cookbook_ini'] unless node['newrelic']['php_agent']['template']['cookbook_ini'].nil?
-  source_ini node['newrelic']['php_agent']['template']['source_ini'] unless node['newrelic']['php_agent']['template']['source_ini'].nil?
-  cookbook node['newrelic']['php_agent']['template']['cookbook'] unless node['newrelic']['php_agent']['template']['cookbook'].nil?
-  source node['newrelic']['php_agent']['template']['source'] unless node['newrelic']['php_agent']['template']['source'].nil?
-  enabled node['newrelic']['application_monitoring']['enabled'] unless node['newrelic']['application_monitoring']['enabled'].nil?
-  logfile node['newrelic']['application_monitoring']['logfile'] unless node['newrelic']['application_monitoring']['logfile'].nil?
-  loglevel node['newrelic']['application_monitoring']['loglevel'] unless node['newrelic']['application_monitoring']['loglevel'].nil?
-  daemon_logfile node['newrelic']['application_monitoring']['daemon']['logfile'] unless node['newrelic']['application_monitoring']['daemon']['logfile'].nil?
-  daemon_loglevel node['newrelic']['application_monitoring']['daemon']['loglevel'] unless node['newrelic']['application_monitoring']['daemon']['loglevel'].nil?
-  daemon_port node['newrelic']['application_monitoring']['daemon']['port'] unless node['newrelic']['application_monitoring']['daemon']['port'].nil?
-  daemon_max_threads node['newrelic']['application_monitoring']['daemon']['max_threads'] unless node['newrelic']['application_monitoring']['daemon']['max_threads'].nil?
-  daemon_ssl NewRelic.to_boolean(node['newrelic']['application_monitoring']['daemon']['ssl']) unless node['newrelic']['application_monitoring']['daemon']['ssl'].nil?
-  daemon_ssl_ca_path node['newrelic']['application_monitoring']['daemon']['ssl_ca_path'] unless node['newrelic']['application_monitoring']['daemon']['ssl_ca_path'].nil?
-  daemon_ssl_ca_bundle node['newrelic']['application_monitoring']['daemon']['ssl_ca_bundle'] unless node['newrelic']['application_monitoring']['daemon']['ssl_ca_bundle'].nil?
-  daemon_proxy node['newrelic']['application_monitoring']['daemon']['proxy'] unless node['newrelic']['application_monitoring']['daemon']['proxy'].nil?
-  daemon_pidfile node['newrelic']['application_monitoring']['daemon']['pidfile'] unless node['newrelic']['application_monitoring']['daemon']['pidfile'].nil?
-  daemon_location node['newrelic']['application_monitoring']['daemon']['location'] unless node['newrelic']['application_monitoring']['daemon']['location'].nil?
-  daemon_collector_host node['newrelic']['application_monitoring']['daemon']['collector_host'] unless node['newrelic']['application_monitoring']['daemon']['collector_host'].nil?
-  daemon_dont_launch node['newrelic']['application_monitoring']['daemon']['dont_launch'] unless node['newrelic']['application_monitoring']['daemon']['dont_launch'].nil?
-  capture_params NewRelic.to_boolean(node['newrelic']['application_monitoring']['capture_params']) unless node['newrelic']['application_monitoring']['capture_params'].nil?
-  ignored_params node['newrelic']['application_monitoring']['ignored_params'] unless node['newrelic']['application_monitoring']['ignored_params'].nil?
-  error_collector_enable NewRelic.to_boolean(node['newrelic']['application_monitoring']['error_collector']['enable']) unless node['newrelic']['application_monitoring']['error_collector']['enable'].nil?
-  error_collector_record_database_errors NewRelic.to_boolean(node['newrelic']['application_monitoring']['error_collector']['record_database_errors']) unless node['newrelic']['application_monitoring']['error_collector']['record_database_errors'].nil?
-  error_collector_prioritize_api_errors NewRelic.to_boolean(node['newrelic']['application_monitoring']['error_collector']['prioritize_api_errors']) unless node['newrelic']['application_monitoring']['error_collector']['prioritize_api_errors'].nil?
-  browser_monitoring_auto_instrument NewRelic.to_boolean(node['newrelic']['application_monitoring']['browser_monitoring']['auto_instrument']) unless node['newrelic']['application_monitoring']['browser_monitoring']['auto_instrument'].nil?
-  transaction_tracer_enable NewRelic.to_boolean(node['newrelic']['application_monitoring']['transaction_tracer']['enable']) unless node['newrelic']['application_monitoring']['transaction_tracer']['enable'].nil?
-  transaction_tracer_threshold node['newrelic']['application_monitoring']['transaction_tracer']['threshold'] unless node['newrelic']['application_monitoring']['transaction_tracer']['threshold'].nil?
-  transaction_tracer_detail node['newrelic']['application_monitoring']['transaction_tracer']['detail'] unless node['newrelic']['application_monitoring']['transaction_tracer']['detail'].nil?
-  transaction_tracer_slow_sql NewRelic.to_boolean(node['newrelic']['application_monitoring']['transaction_tracer']['slow_sql']) unless node['newrelic']['application_monitoring']['transaction_tracer']['slow_sql'].nil?
-  transaction_tracer_stack_trace_threshold node['newrelic']['application_monitoring']['transaction_tracer']['stack_trace_threshold'] unless node['newrelic']['application_monitoring']['transaction_tracer']['stack_trace_threshold'].nil?
-  transaction_tracer_explain_threshold node['newrelic']['application_monitoring']['transaction_tracer']['explain_threshold'] unless node['newrelic']['application_monitoring']['transaction_tracer']['explain_threshold'].nil?
-  transaction_tracer_record_sql node['newrelic']['application_monitoring']['transaction_tracer']['record_sql'] unless node['newrelic']['application_monitoring']['transaction_tracer']['record_sql'].nil?
-  transaction_tracer_custom node['newrelic']['application_monitoring']['transaction_tracer']['custom'] unless node['newrelic']['application_monitoring']['transaction_tracer']['custom'].nil?
-  framework node['newrelic']['application_monitoring']['framework'] unless node['newrelic']['application_monitoring']['framework'].nil?
-  webtransaction_name_remove_trailing_path NewRelic.to_boolean(node['newrelic']['application_monitoring']['webtransaction']['name']['remove_trailing_path']) unless node['newrelic']['application_monitoring']['webtransaction']['name']['remove_trailing_path'].nil?
-  webtransaction_name_functions node['newrelic']['application_monitoring']['webtransaction']['name']['functions'] unless node['newrelic']['application_monitoring']['webtransaction']['name']['functions'].nil?
-  webtransaction_name_files node['newrelic']['application_monitoring']['webtransaction']['name']['files'] unless node['newrelic']['application_monitoring']['webtransaction']['name']['files'].nil?
-  cross_application_tracer_enable NewRelic.to_boolean(node['newrelic']['application_monitoring']['cross_application_tracer']['enable']) unless node['newrelic']['application_monitoring']['cross_application_tracer']['enable'].nil?
+  config_file node['newrelic']['php_agent']['config_file']
+  startup_mode node['newrelic']['php_agent']['startup_mode']
+  app_name node['newrelic']['application_monitoring']['app_name']
+  high_security NewRelic.to_string_from_boolean(node['newrelic']['application_monitoring']['high_security'])
+  install_silently node['newrelic']['php_agent']['install_silently']
+  config_file_to_be_deleted node['newrelic']['php_agent']['config_file_to_be_deleted']
+  service_name node['newrelic']['php_agent']['web_server']['service_name']
+  execute_php5enmod NewRelic.to_string_from_boolean(node['newrelic']['php_agent']['execute_php5enmod'])
+  cookbook_ini node['newrelic']['php_agent']['template']['cookbook_ini']
+  source_ini node['newrelic']['php_agent']['template']['source_ini']
+  cookbook node['newrelic']['php_agent']['template']['cookbook']
+  source node['newrelic']['php_agent']['template']['source']
+  enabled node['newrelic']['application_monitoring']['enabled']
+  logfile node['newrelic']['application_monitoring']['logfile']
+  loglevel node['newrelic']['application_monitoring']['loglevel']
+  daemon_logfile node['newrelic']['application_monitoring']['daemon']['logfile']
+  daemon_loglevel node['newrelic']['application_monitoring']['daemon']['loglevel']
+  daemon_port node['newrelic']['application_monitoring']['daemon']['port']
+  daemon_max_threads node['newrelic']['application_monitoring']['daemon']['max_threads']
+  daemon_ssl NewRelic.to_string_from_boolean(node['newrelic']['application_monitoring']['daemon']['ssl'])
+  daemon_ssl_ca_path node['newrelic']['application_monitoring']['daemon']['ssl_ca_path']
+  daemon_ssl_ca_bundle node['newrelic']['application_monitoring']['daemon']['ssl_ca_bundle']
+  daemon_proxy node['newrelic']['application_monitoring']['daemon']['proxy']
+  daemon_pidfile node['newrelic']['application_monitoring']['daemon']['pidfile']
+  daemon_location node['newrelic']['application_monitoring']['daemon']['location']
+  daemon_collector_host node['newrelic']['application_monitoring']['daemon']['collector_host']
+  daemon_dont_launch node['newrelic']['application_monitoring']['daemon']['dont_launch']
+  capture_params NewRelic.to_string_from_boolean(node['newrelic']['application_monitoring']['capture_params'])
+  ignored_params node['newrelic']['application_monitoring']['ignored_params']
+  error_collector_enable NewRelic.to_string_from_boolean(node['newrelic']['application_monitoring']['error_collector']['enable'])
+  error_collector_record_database_errors NewRelic.to_string_from_boolean(node['newrelic']['application_monitoring']['error_collector']['record_database_errors'])
+  error_collector_prioritize_api_errors NewRelic.to_string_from_boolean(node['newrelic']['application_monitoring']['error_collector']['prioritize_api_errors'])
+  browser_monitoring_auto_instrument NewRelic.to_string_from_boolean(node['newrelic']['application_monitoring']['browser_monitoring']['auto_instrument'])
+  transaction_tracer_enable NewRelic.to_string_from_boolean(node['newrelic']['application_monitoring']['transaction_tracer']['enable'])
+  transaction_tracer_threshold node['newrelic']['application_monitoring']['transaction_tracer']['threshold']
+  transaction_tracer_detail node['newrelic']['application_monitoring']['transaction_tracer']['detail']
+  transaction_tracer_slow_sql NewRelic.to_string_from_boolean(node['newrelic']['application_monitoring']['transaction_tracer']['slow_sql'])
+  transaction_tracer_stack_trace_threshold node['newrelic']['application_monitoring']['transaction_tracer']['stack_trace_threshold']
+  transaction_tracer_explain_threshold node['newrelic']['application_monitoring']['transaction_tracer']['explain_threshold']
+  transaction_tracer_record_sql node['newrelic']['application_monitoring']['transaction_tracer']['record_sql']
+  transaction_tracer_custom node['newrelic']['application_monitoring']['transaction_tracer']['custom']
+  framework node['newrelic']['application_monitoring']['framework']
+  webtransaction_name_remove_trailing_path NewRelic.to_string_from_boolean(node['newrelic']['application_monitoring']['webtransaction']['name']['remove_trailing_path'])
+  webtransaction_name_functions node['newrelic']['application_monitoring']['webtransaction']['name']['functions']
+  webtransaction_name_files node['newrelic']['application_monitoring']['webtransaction']['name']['files']
+  cross_application_tracer_enable NewRelic.to_string_from_boolean(node['newrelic']['application_monitoring']['cross_application_tracer']['enable'])
 end

--- a/recipes/ruby_agent.rb
+++ b/recipes/ruby_agent.rb
@@ -13,7 +13,7 @@ gem_package 'newrelic_rpm' do
   action node['newrelic']['ruby_agent']['agent_action']
 end
 
-if node['newrelic']['application_monitoring']['app_name'].nil?
+unless node['newrelic']['application_monitoring']['app_name'] && !node['newrelic']['application_monitoring']['app_name'].empty?
   node.set['newrelic']['application_monitoring']['app_name'] = node['hostname']
 end
 

--- a/recipes/server_monitor_agent.rb
+++ b/recipes/server_monitor_agent.rb
@@ -7,26 +7,26 @@
 
 newrelic_server_monitor 'Install' do
   license NewRelic.server_monitoring_license(node)
-  logfile node['newrelic']['server_monitoring']['logfile'] unless node['newrelic']['server_monitoring']['logfile'].nil?
-  loglevel node['newrelic']['server_monitoring']['loglevel'] unless node['newrelic']['server_monitoring']['loglevel'].nil?
-  proxy node['newrelic']['server_monitoring']['proxy'] unless node['newrelic']['server_monitoring']['proxy'].nil?
-  ssl NewRelic.to_boolean(node['newrelic']['server_monitoring']['ssl']) unless node['newrelic']['server_monitoring']['ssl'].nil?
-  ssl_ca_bundle node['newrelic']['server_monitoring']['ssl_ca_bundle'] unless node['newrelic']['server_monitoring']['ssl_ca_bundle'].nil?
-  ssl_ca_path node['newrelic']['server_monitoring']['ssl_ca_path'] unless node['newrelic']['server_monitoring']['ssl_ca_path'].nil?
-  hostname node['newrelic']['server_monitoring']['hostname'] unless node['newrelic']['server_monitoring']['hostname'].nil?
-  labels node['newrelic']['server_monitoring']['labels'] unless node['newrelic']['server_monitoring']['labels'].nil?
-  pidfile node['newrelic']['server_monitoring']['pidfile'] unless node['newrelic']['server_monitoring']['pidfile'].nil?
-  collector_host node['newrelic']['server_monitoring']['collector_host'] unless node['newrelic']['server_monitoring']['collector_host'].nil?
-  timeout node['newrelic']['server_monitoring']['timeout'] unless node['newrelic']['server_monitoring']['timeout'].nil?
-  config_file_user node['newrelic']['server_monitor_agent']['config_file_user'] unless node['newrelic']['server_monitor_agent']['config_file_user'].nil?
-  config_file_group node['newrelic']['server_monitor_agent']['config_file_group'] unless node['newrelic']['server_monitor_agent']['config_file_group'].nil?
-  service_notify_action node['newrelic']['server_monitor_agent']['service_notify_action'] unless node['newrelic']['server_monitor_agent']['service_notify_action'].nil?
-  service_actions node['newrelic']['server_monitor_agent']['service_actions'] unless node['newrelic']['server_monitor_agent']['service_actions'].nil?
-  windows_version node['newrelic']['server_monitor_agent']['windows_version'] unless node['newrelic']['server_monitor_agent']['windows_version'].nil?
-  windows32_checksum node['newrelic']['server_monitor_agent']['windows32_checksum'] unless node['newrelic']['server_monitor_agent']['windows32_checksum'].nil?
-  windows64_checksum node['newrelic']['server_monitor_agent']['windows64_checksum'] unless node['newrelic']['server_monitor_agent']['windows64_checksum'].nil?
-  cookbook node['newrelic']['server_monitor_agent']['template']['cookbook'] unless node['newrelic']['server_monitor_agent']['template']['cookbook'].nil?
-  source node['newrelic']['server_monitor_agent']['template']['source'] unless node['newrelic']['server_monitor_agent']['template']['source'].nil?
-  service_name node['newrelic']['server_monitor_agent']['service_name'] unless node['newrelic']['server_monitor_agent']['service_name'].nil?
-  config_path node['newrelic']['server_monitor_agent']['config_path'] unless node['newrelic']['server_monitor_agent']['config_path'].nil?
+  logfile node['newrelic']['server_monitoring']['logfile']
+  loglevel node['newrelic']['server_monitoring']['loglevel']
+  proxy node['newrelic']['server_monitoring']['proxy']
+  ssl NewRelic.to_string_from_boolean(node['newrelic']['server_monitoring']['ssl'])
+  ssl_ca_bundle node['newrelic']['server_monitoring']['ssl_ca_bundle']
+  ssl_ca_path node['newrelic']['server_monitoring']['ssl_ca_path']
+  hostname node['newrelic']['server_monitoring']['hostname']
+  labels node['newrelic']['server_monitoring']['labels']
+  pidfile node['newrelic']['server_monitoring']['pidfile']
+  collector_host node['newrelic']['server_monitoring']['collector_host']
+  timeout node['newrelic']['server_monitoring']['timeout']
+  config_file_user node['newrelic']['server_monitor_agent']['config_file_user']
+  config_file_group node['newrelic']['server_monitor_agent']['config_file_group']
+  service_notify_action node['newrelic']['server_monitor_agent']['service_notify_action']
+  service_actions node['newrelic']['server_monitor_agent']['service_actions']
+  windows_version node['newrelic']['server_monitor_agent']['windows_version']
+  windows32_checksum node['newrelic']['server_monitor_agent']['windows32_checksum']
+  windows64_checksum node['newrelic']['server_monitor_agent']['windows64_checksum']
+  cookbook node['newrelic']['server_monitor_agent']['template']['cookbook']
+  source node['newrelic']['server_monitor_agent']['template']['source']
+  service_name node['newrelic']['server_monitor_agent']['service_name']
+  config_path node['newrelic']['server_monitor_agent']['config_path']
 end

--- a/resources/agent_php.rb
+++ b/resources/agent_php.rb
@@ -12,24 +12,24 @@ attribute :license, :kind_of => String, :default => nil
 attribute :config_file, :kind_of => String, :default => nil
 attribute :startup_mode, :kind_of => String, :default => 'agent'
 attribute :app_name, :kind_of => String, :default => nil
-attribute :high_security, :kind_of => [TrueClass, FalseClass], :default => false
-attribute :install_silently, :kind_of => [TrueClass, FalseClass], :default => false
+attribute :high_security, :kind_of => [TrueClass, FalseClass, String], :default => 'false'
+attribute :install_silently, :kind_of => [TrueClass, FalseClass, String], :default => 'false'
 attribute :config_file_to_be_deleted, :kind_of => String, :default => nil
 attribute :service_name, :kind_of => String, :default => nil
-attribute :execute_php5enmod, :kind_of => [TrueClass, FalseClass], :default => false
+attribute :execute_php5enmod, :kind_of => [TrueClass, FalseClass, String], :default => 'false'
 attribute :cookbook_ini, :kind_of => String, :default => 'newrelic'
 attribute :source_ini, :kind_of => String, :default => 'agent/php/newrelic.ini.erb'
 attribute :cookbook, :kind_of => String, :default => 'newrelic'
 attribute :source, :kind_of => String, :default => 'agent/php/newrelic.cfg.erb'
 
-attribute :enabled, :kind_of => [TrueClass, FalseClass], :default => true
+attribute :enabled, :kind_of => [TrueClass, FalseClass, String], :default => 'true'
 attribute :logfile, :kind_of => String, :default => nil
 attribute :loglevel, :kind_of => String, :default => nil
 attribute :daemon_logfile, :kind_of => String, :default => '/var/log/newrelic/newrelic-daemon.log'
 attribute :daemon_loglevel, :kind_of => String, :default => nil
 attribute :daemon_port, :kind_of => String, :default => nil
 attribute :daemon_max_threads, :kind_of => String, :default => nil
-attribute :daemon_ssl, :kind_of => [TrueClass, FalseClass], :default => true
+attribute :daemon_ssl, :kind_of => [TrueClass, FalseClass, String], :default => 'true'
 attribute :daemon_ssl_ca_path, :kind_of => String, :default => nil
 attribute :daemon_ssl_ca_bundle, :kind_of => String, :default => nil
 attribute :daemon_proxy, :kind_of => String, :default => nil
@@ -37,22 +37,22 @@ attribute :daemon_pidfile, :kind_of => String, :default => nil
 attribute :daemon_location, :kind_of => String, :default => nil
 attribute :daemon_collector_host, :kind_of => String, :default => nil
 attribute :daemon_dont_launch, :kind_of => String, :default => nil
-attribute :capture_params, :kind_of => [TrueClass, FalseClass], :default => false
+attribute :capture_params, :kind_of => [TrueClass, FalseClass, String], :default => 'false'
 attribute :ignored_params, :kind_of => String, :default => nil
-attribute :error_collector_enable, :kind_of => [TrueClass, FalseClass], :default => true
-attribute :error_collector_record_database_errors, :kind_of => [TrueClass, FalseClass], :default => true
-attribute :error_collector_prioritize_api_errors, :kind_of => [TrueClass, FalseClass], :default => false
-attribute :browser_monitoring_auto_instrument, :kind_of => [TrueClass, FalseClass], :default => true
-attribute :transaction_tracer_enable, :kind_of => [TrueClass, FalseClass], :default => true
+attribute :error_collector_enable, :kind_of => [TrueClass, FalseClass, String], :default => 'true'
+attribute :error_collector_record_database_errors, :kind_of => [TrueClass, FalseClass, String], :default => 'true'
+attribute :error_collector_prioritize_api_errors, :kind_of => [TrueClass, FalseClass, String], :default => 'false'
+attribute :browser_monitoring_auto_instrument, :kind_of => [TrueClass, FalseClass, String], :default => 'true'
+attribute :transaction_tracer_enable, :kind_of => [TrueClass, FalseClass, String], :default => 'true'
 attribute :transaction_tracer_threshold, :kind_of => String, :default => nil
 attribute :transaction_tracer_detail, :kind_of => String, :default => nil
-attribute :transaction_tracer_slow_sql, :kind_of => [TrueClass, FalseClass], :default => true
+attribute :transaction_tracer_slow_sql, :kind_of => [TrueClass, FalseClass, String], :default => 'true'
 attribute :transaction_tracer_stack_trace_threshold, :kind_of => String, :default => nil
 attribute :transaction_tracer_explain_threshold, :kind_of => String, :default => nil
 attribute :transaction_tracer_record_sql, :kind_of => String, :default => nil
 attribute :transaction_tracer_custom, :kind_of => String, :default => nil
 attribute :framework, :kind_of => String, :default => nil
-attribute :webtransaction_name_remove_trailing_path, :kind_of => [TrueClass, FalseClass], :default => false
+attribute :webtransaction_name_remove_trailing_path, :kind_of => [TrueClass, FalseClass, String], :default => 'false'
 attribute :webtransaction_name_functions, :kind_of => String, :default => nil
 attribute :webtransaction_name_files, :kind_of => String, :default => nil
-attribute :cross_application_tracer_enable, :kind_of => [TrueClass, FalseClass], :default => true
+attribute :cross_application_tracer_enable, :kind_of => [TrueClass, FalseClass, String], :default => 'true'

--- a/resources/server_monitor.rb
+++ b/resources/server_monitor.rb
@@ -13,7 +13,7 @@ attribute :license, :kind_of => String, :default => nil
 attribute :logfile, :kind_of => String, :default => nil
 attribute :loglevel, :kind_of => String, :default => nil
 attribute :proxy, :kind_of => String, :default => nil
-attribute :ssl, :kind_of => String, :default => nil
+attribute :ssl, :kind_of => [TrueClass, FalseClass, String], :default => nil
 attribute :ssl_ca_bundle, :kind_of => String, :default => nil
 attribute :ssl_ca_path, :kind_of => String, :default => nil
 attribute :hostname, :kind_of => String, :default => nil

--- a/templates/default/agent/newrelic.yml.erb
+++ b/templates/default/agent/newrelic.yml.erb
@@ -23,7 +23,7 @@ common: &default_settings
   # Use this setting to force the agent to run or not run.
   # Default is true.
   # agent_enabled: true
-  <% if @enabled.nil? -%>
+  <% unless @enabled && !@enabled.empty? -%>
   agent_enabled: true
   <% else -%>
   agent_enabled: <%= @enabled %>
@@ -49,7 +49,7 @@ common: &default_settings
   # For example, to report data to"My Application" and "My Application 2" use this:
   # app_name: My Application;My Application 2
   # This setting is required.
-  <% if @app_name.nil? %>
+  <% unless @app_name && !@app_name.empty? %>
   app_name: <%= @agent_type %> Application
   <% else %>
   app_name: <%= @app_name %>
@@ -58,7 +58,7 @@ common: &default_settings
   # In order for high security to be enabled, this property must be set to true and the high security property in the New Relic user
   # interface must be enabled. Enabling high security means SSL is turned on, request and message queue parameters are not collected, and
   # SQL cannot be sent to New Relic in its raw form.
-  <% unless @high_security.nil? %>
+  <% if @high_security && !@high_security.empty? %>
   high_security: <%= @high_security %>
   <% end %>
 
@@ -67,7 +67,7 @@ common: &default_settings
   # This setting is dynamic, so changes do not require restarting your application.
   # The levels in increasing order of verboseness are: off, severe, warning, info, fine, finer, finest
   # Default is info.
-  <% if @loglevel.nil? %>
+  <% unless @loglevel && !@loglevel.empty? %>
   log_level: info
   <% else %>
   log_level: <%= @loglevel %>
@@ -76,7 +76,7 @@ common: &default_settings
   # Log all data to and from New Relic in plain text.
   # This setting is dynamic, so changes do not require restarting your application.
   # Default is false.
-  <% if @audit_mode.nil? %>
+  <% unless @audit_mode && !@audit_mode.empty? %>
   audit_mode: true
   <% else %>
   audit_mode: <%= @audit_mode %>
@@ -84,7 +84,7 @@ common: &default_settings
 
   # The number of log files to use.
   # Default is 1.
-  <% if @log_file_count.nil? %>
+  <% unless @log_file_count && !@log_file_count.empty? %>
   log_file_count: 1
   <% else %>
   log_file_count: <%= @log_file_count %>
@@ -94,7 +94,7 @@ common: &default_settings
   # The log_file_count must be set greater than 1.
   # Default is 0 (no limit).
   #log_limit_in_kbytes: 0
-  <% if @log_limit_in_kbytes.nil? %>
+  <% unless @log_limit_in_kbytes && !@log_limit_in_kbytes.empty? %>
   log_limit_in_kbytes: 0
   <% else %>
   log_limit_in_kbytes: <%= @log_limit_in_kbytes %>
@@ -103,7 +103,7 @@ common: &default_settings
   # Override other log rolling configuration and roll the logs daily.
   # Default is false.
   #log_daily: false
-  <% if @log_daily.nil? %>
+  <% unless @log_daily && !@log_daily.empty? %>
   log_daily: false
   <% else %>
   log_daily: <%= @log_daily %>
@@ -111,7 +111,7 @@ common: &default_settings
 
   # The name of the log file.
   # Default is newrelic_agent.log.
-  <% if @logfile.nil? %>
+  <% unless @logfile && !@logfile.empty? %>
   log_file: newrelic_agent.log
   <% else %>
   log_file: <%= @logfile %>
@@ -119,7 +119,7 @@ common: &default_settings
 
   # The log file directory.
   # Default is the logs directory in the newrelic.jar parent directory.
-  <% if @logfile_path.nil? %>
+  <% unless @logfile_path && !@logfile_path.empty? %>
   #log_file_path:
   <% else %>
   log_file_path: <%= @logfile_path %>
@@ -132,7 +132,7 @@ common: &default_settings
   # application code, so response times will not be directly affected
   # by this change.
   # Default is true.
-  <% if @daemon_ssl.nil? %>
+  <% unless @daemon_ssl && !@daemon_ssl.empty? %>
   ssl: true
   <% else %>
   ssl: <%= @daemon_ssl %>
@@ -149,16 +149,16 @@ common: &default_settings
   # proxy_port: 8080
   # proxy_user: username
   # proxy_password: password
-  <% unless @daemon_proxy_host.nil? %>
+  <% if @daemon_proxy_host && !@daemon_proxy_host.empty? %>
   proxy_host: <%= @daemon_proxy_host %>
   <% end %>
-  <% unless @daemon_proxy_port.nil? %>
+  <% if @daemon_proxy_port && !@daemon_proxy_port.empty? %>
   proxy_port: <%= @daemon_proxy_port %>
   <% end %>
-  <% unless @daemon_proxy_user.nil? %>
+  <% if @daemon_proxy_user && !@daemon_proxy_user.empty? %>
   proxy_user: <%= @daemon_proxy_user %>
   <% end %>
-  <% unless @daemon_proxy_password.nil? %>
+  <% if @daemon_proxy_password && !@daemon_proxy_password.empty? %>
   proxy_password: <%= @daemon_proxy_password %>
   <% end %>
 
@@ -166,7 +166,7 @@ common: &default_settings
   # whether or not to capture HTTP params.  When true, frameworks can
   # exclude HTTP parameters from being captured.
   # Default is false.
-  <% if @capture_params.nil? %>
+  <% unless @capture_params && !@capture_params.empty? %>
   capture_params: false
   <% else %>
   capture_params: <%= @capture_params %>
@@ -174,7 +174,7 @@ common: &default_settings
 
   # Tells transaction tracer and error collector to not to collect
   # specific http request parameters.
-  <% if @ignored_params.nil? %>
+  <% unless @ignored_params && !@ignored_params.empty? %>
   # ignored_params: credit_card, ssn, password
   <% else %>
   ignored_params: <%= @ignored_params %>
@@ -189,7 +189,7 @@ common: &default_settings
     # Transaction tracer is enabled by default. Set this to false to
     # turn it off. This feature is only available at the higher product levels.
     # Default is true.
-    <% if @transaction_tracer_enable.nil? %>
+    <% unless @transaction_tracer_enable && !@transaction_tracer_enable.empty? %>
     enabled: true
     <% else %>
     enabled: <%= @transaction_tracer_enable %>
@@ -202,7 +202,7 @@ common: &default_settings
     # which will use the threshold for the "Frustrated" Apdex level
     # (greater than four times the apdex_t value).
     # Default is apdex_f.
-    <% if @transaction_tracer_threshold.nil? %>
+    <% unless @transaction_tracer_threshold && !@transaction_tracer_threshold.empty? %>
     transaction_threshold: apdex_f
     <% else %>
     transaction_threshold: <%= @transaction_tracer_threshold %>
@@ -213,7 +213,7 @@ common: &default_settings
     # SQL, "raw" which sends the SQL statement in its original form,
     # and "obfuscated", which strips out numeric and string literals.
     # Default is obfuscated.
-    <% if @transaction_tracer_record_sql.nil? %>
+    <% unless @transaction_tracer_record_sql && !@transaction_tracer_record_sql.empty? %>
     record_sql: obfuscated
     <% else %>
     record_sql: <%= @transaction_tracer_record_sql %>
@@ -233,7 +233,7 @@ common: &default_settings
     # then capture and send to New Relic the current stack trace. This is
     # helpful for pinpointing where long SQL calls originate from.
     # Default is 0.5 seconds.
-    <% if @transaction_tracer_stack_trace_threshold.nil? %>
+    <% unless @transaction_tracer_stack_trace_threshold && !@transaction_tracer_stack_trace_threshold.empty? %>
     stack_trace_threshold: 0.5
     <% else %>
     stack_trace_threshold: <%= @transaction_tracer_stack_trace_threshold %>
@@ -242,7 +242,7 @@ common: &default_settings
     # Determines whether the agent will capture query plans for slow
     # SQL queries. Only supported for MySQL and PostgreSQL.
     # Default is true.
-    <% if @transaction_tracer_slow_sql.nil? %>
+    <% unless @transaction_tracer_slow_sql && !@transaction_tracer_slow_sql.empty? %>
     explain_enabled: true
     <% else %>
     explain_enabled: <%= @transaction_tracer_slow_sql %>
@@ -251,7 +251,7 @@ common: &default_settings
     # Threshold for query execution time below which query plans will not
     # not be captured.  Relevant only when `explain_enabled` is true.
     # Default is 0.5 seconds.
-    <% if @transaction_tracer_explain_threshold.nil? %>
+    <% unless @transaction_tracer_explain_threshold && !@transaction_tracer_explain_threshold.empty? %>
     explain_threshold: 0.5
     <% else %>
     explain_threshold: <%= @transaction_tracer_explain_threshold %>
@@ -271,7 +271,7 @@ common: &default_settings
     # Error collector is enabled by default. Set this to false to turn
     # it off. This feature is only available at the higher product levels.
     # Default is true.
-    <% if @error_collector_enable.nil? %>
+    <% unless @error_collector_enable && !@error_collector_enable.empty? %>
     enabled: true
     <% else %>
     enabled: <%= @error_collector_enable %>
@@ -281,7 +281,7 @@ common: &default_settings
     # to a comma separated list of full class names.
     #
     # ignore_errors:
-    <% unless @error_collector_ignore_errors.nil? %>
+    <% if @error_collector_ignore_errors && !@error_collector_ignore_errors.empty? %>
     ignore_errors: <%= @error_collector_ignore_errors %>
     <% end %>
 
@@ -290,7 +290,7 @@ common: &default_settings
     # When this property is commented out it defaults to ignoring 404s.
     #
     # ignore_status_codes: 404
-    <% unless @error_collector_ignore_status_codes.nil? %>
+    <% if @error_collector_ignore_status_codes && !@error_collector_ignore_status_codes.empty? %>
     ignore_status_codes: <%= @error_collector_ignore_status_codes %>
     <% end %>
 
@@ -301,7 +301,7 @@ common: &default_settings
   cross_application_tracer:
     # Set to true to enable cross application tracing.
     # Default is true.
-    <%if @cross_application_tracer_enable.nil? %>
+    <% unless @cross_application_tracer_enable && !@cross_application_tracer_enable.empty? %>
     enabled: true
     <% else %>
     enabled: <%= @cross_application_tracer_enable %>
@@ -313,7 +313,7 @@ common: &default_settings
 
     # Set to false to disable the thread profiler.
     # Default is true.
-    <% if @thread_profiler_enable.nil? %>
+    <% unless @thread_profiler_enable && !@thread_profiler_enable.empty? %>
     enabled: true
     <% else %>
     enabled: <%= @thread_profiler_enable %>
@@ -328,7 +328,7 @@ common: &default_settings
     # By default the agent automatically inserts API calls in compiled JSPs to
     # inject the monitoring JavaScript into web pages.
     # Set this attribute to false to turn off this behavior.
-    <% if @browser_monitoring_auto_instrument.nil? %>
+    <% unless @browser_monitoring_auto_instrument && !@browser_monitoring_auto_instrument.empty? %>
     auto_instrument: true
     <% else %>
     auto_instrument: <%= @browser_monitoring_auto_instrument %>

--- a/templates/default/agent/nodejs/newrelic.js.erb
+++ b/templates/default/agent/nodejs/newrelic.js.erb
@@ -23,7 +23,7 @@ exports.config = {
          * issues with the agent, 'info' and higher will impose the least overhead on
          * production applications.
          */
-        level: '<%= @app_log_level %>'<% unless @app_log_filepath.nil? -%>,
+        level: '<%= @app_log_level %>'<% if @app_log_filepath && !@app_log_filepath.empty? -%>,
         filepath: '<%= @app_log_filepath %>'
         <% else -%>
 

--- a/templates/default/agent/php/newrelic.cfg.erb
+++ b/templates/default/agent/php/newrelic.cfg.erb
@@ -55,7 +55,7 @@
 #          which process to monitor or kill.
 # Default: OS-dependent. Uses a filename of newrelic-daemon.pid in the first
 #          directory from the list /var/run or /var/pid that is found.
-<% if @resource.daemon_pidfile.nil? %>
+<% unless @resource.daemon_pidfile && !@resource.daemon_pidfile.empty? %>
 #pidfile=/var/run/newrelic-daemon.pid
 <% else %>
 pidfile=<%= @resource.daemon_pidfile %>
@@ -69,7 +69,7 @@ pidfile=<%= @resource.daemon_pidfile %>
 #          will not start up. The amount of information sent to this file is
 #          controlled by the loglevel settings, defined below.
 # Default: /var/log/newrelic/newrelic-daemon.log
-<% if @resource.daemon_logfile.nil? %>
+<% unless @resource.daemon_logfile && !@resource.daemon_logfile.empty? %>
 #logfile=/var/log/newrelic/newrelic-daemon.log
 <% else %>
 logfile=<%= @resource.daemon_logfile %>
@@ -90,7 +90,7 @@ logfile=<%= @resource.daemon_logfile %>
 #          debug - very verbose, includes messages only relevant to support
 #          verbosedebug - extremely verbose, creates massive log files
 # Default: info
-<% if @resource.daemon_loglevel.nil? %>
+<% unless @resource.daemon_loglevel && !@resource.daemon_loglevel.empty? %>
 #loglevel=info
 <% else %>
 loglevel=<%= @resource.daemon_loglevel %>
@@ -106,7 +106,7 @@ loglevel=<%= @resource.daemon_loglevel %>
 #          the super-user. This is a fundamental OS limitation and not one
 #          imposed by the daemon itself.
 # Default: 33142
-<% if @resource.daemon_port.nil? %>
+<% unless @resource.daemon_port && !@resource.daemon_port.empty? %>
 #port=33142
 <% else %>
 port=<%= @resource.daemon_port %>
@@ -123,7 +123,7 @@ port=<%= @resource.daemon_port %>
 #          you may need to use the ssl_ca_bundle or ssl_ca_path variables
 #          below.
 # Default: false
-<% if @resource.daemon_ssl.nil? %>
+<% unless @resource.daemon_ssl && !@resource.daemon_ssl.empty? %>
 #ssl=false
 <% else %>
 ssl=<%= @resource.daemon_ssl %>
@@ -144,7 +144,7 @@ ssl=<%= @resource.daemon_ssl %>
 #          someuser@proxy.mydomain.com:4321
 #          proxy.mydomain.com
 # Default: none
-<% if @resource.daemon_proxy.nil? %>
+<% unless @resource.daemon_proxy && !@resource.daemon_proxy.empty? %>
 #proxy=
 <% else %>
 proxy=<%= @resource.daemon_proxy %>
@@ -161,7 +161,7 @@ proxy=<%= @resource.daemon_proxy %>
 # Default: Looks for one of two files: /etc/pki/tls/certs/ca-bundle.crt or
 #          /etc/ssl/certs/ca-certificates.crt.
 #
-<% if @resource.daemon_ssl_ca_bundle.nil? %>
+<% unless @resource.daemon_ssl_ca_bundle && !@resource.daemon_ssl_ca_bundle.empty? %>
 #ssl_ca_bundle=
 <% else %>
 ssl_ca_bundle=<%= @resource.daemon_ssl_ca_bundle %>
@@ -174,7 +174,7 @@ ssl_ca_bundle=<%= @resource.daemon_ssl_ca_bundle %>
 #          installation uses a sub-directory with a list of CA certificates.
 #          Set this variable to point to that directory.
 # Default: /etc/ssl/certs
-<% if @resource.daemon_ssl_ca_path.nil? %>
+<% unless @resource.daemon_ssl_ca_path && !@resource.daemon_ssl_ca_path.empty? %>
 #ssl_ca_path=
 <% else %>
 ssl_ca_path=<%= @resource.daemon_ssl_ca_path %>
@@ -190,7 +190,7 @@ ssl_ca_path=<%= @resource.daemon_ssl_ca_path %>
 #          have resource usage (memory, CPU etc.) implications so do not just
 #          increase this arbitrarily.
 # Default: 8
-<% if @resource.daemon_max_threads.nil? %>
+<% unless @resource.daemon_max_threads && !@resource.daemon_max_threads.empty? %>
 #max_threads=8
 <% else %>
 max_threads=<%= @resource.daemon_max_threads %>
@@ -206,7 +206,7 @@ max_threads=<%= @resource.daemon_max_threads %>
 #          circumstances, and then only on instruction from a New Relic sales
 #          person or support staff member.
 # Default: collector.newrelic.com
-<% if @resource.daemon_collector_host.nil? %>
+<% unless @resource.daemon_collector_host && !@resource.daemon_collector_host.empty? %>
 #collector_host=collector.newrelic.com
 <% else %>
 collector_host=<%= @resource.daemon_collector_host %>

--- a/templates/default/agent/php/newrelic.ini.erb
+++ b/templates/default/agent/php/newrelic.ini.erb
@@ -26,7 +26,7 @@ extension=newrelic.so
 ;          agent will not initialize at all. However, you can selectively
 ;          disable the agent on a per-directory basis.
 ;
-<% if @resource.enabled.nil? %>
+<% unless @resource.enabled && !@resource.enabled.empty? %>
 ;newrelic.enabled = true
 <% else %>
 newrelic.enabled = <%= @resource.enabled %>
@@ -66,7 +66,7 @@ newrelic.license = "<%= @resource.license %>"
 ; Default: none
 ; Info   : Sets the name of the file to send log messages to.
 ;
-<% if @resource.logfile.nil? %>
+<% unless @resource.logfile && !@resource.logfile.empty? %>
 newrelic.logfile = "/var/log/newrelic/php_agent.log"
 <% else %>
 newrelic.logfile = "<%= @resource.logfile %>"
@@ -82,7 +82,7 @@ newrelic.logfile = "<%= @resource.logfile %>"
 ;          the guidance of technical support. This option has changed meaning
 ;          fairly significantly from agent versions 1.x and 2.x.
 ;
-<% if @resource.loglevel.nil? %>
+<% unless @resource.loglevel && !@resource.loglevel.empty? %>
 ;newrelic.loglevel = "info"
 <% else %>
 newrelic.loglevel = "<%= @resource.loglevel %>"
@@ -99,7 +99,7 @@ newrelic.loglevel = "<%= @resource.loglevel %>"
 ;          list is considered the 'primary' application name and must be unique
 ;          for each account / license key.
 ;
-<% if @resource.app_name.nil? %>
+<% unless @resource.app_name && !@resource.app_name.empty? %>
 ;newrelic.appname = "PHP Application"
 <% else %>
 newrelic.appname = "<%= @resource.app_name %>"
@@ -147,7 +147,7 @@ newrelic.daemon.logfile = "<%= @resource.daemon_logfile %>"
 ;          the guidance of technical support. This option has changed meaning
 ;          fairly significantly from agent versions 1.x and 2.x.
 ;
-<% if @resource.daemon_loglevel.nil? %>
+<% unless @resource.daemon_loglevel && !@resource.daemon_loglevel.empty? %>
 ;newrelic.daemon.loglevel = "info"
 <% else %>
 newrelic.daemon.loglevel = "<%= @resource.daemon_loglevel %>"
@@ -162,7 +162,7 @@ newrelic.daemon.loglevel = "<%= @resource.daemon_loglevel %>"
 ;          daemon listens on. This is used for the worker processes and CLI
 ;          invocations to communicate with the daemon.
 ;
-<% if @resource.daemon_port.nil? %>
+<% unless @resource.daemon_port && !@resource.daemon_port.empty? %>
 ;newrelic.daemon.port = 33142
 <% else %>
 newrelic.daemon.port = <%= @resource.daemon_port %>
@@ -177,7 +177,7 @@ newrelic.daemon.port = <%= @resource.daemon_port %>
 ;          used for processing requests from each agent. The minimum is 4 and
 ;          the maximum is 128.
 ;
-<% if @resource.daemon_max_threads.nil? %>
+<% unless @resource.daemon_max_threads && !@resource.daemon_max_threads.empty? %>
 ;newrelic.daemon.max_threads = 8
 <% else %>
 newrelic.daemon.max_threads = <%= @resource.daemon_max_threads %>
@@ -195,7 +195,7 @@ newrelic.daemon.max_threads = <%= @resource.daemon_max_threads %>
 ;          PEM-encoded certificate file, or a directory that contains a list
 ;          of such files, using the following two options.
 ;
-<% if @resource.daemon_ssl.nil? %>
+<% unless @resource.daemon_ssl && !@resource.daemon_ssl.empty? %>
 ;newrelic.daemon.ssl = false
 <% else %>
 newrelic.daemon.ssl = <%= @resource.daemon_ssl %>
@@ -211,12 +211,12 @@ newrelic.daemon.ssl = <%= @resource.daemon_ssl %>
 ;          of certificate authorities. May be required when you enable https
 ;          support above.
 ;
-<% if @resource.daemon_ssl_ca_path.nil? %>
+<% unless @resource.daemon_ssl_ca_path && !@resource.daemon_ssl_ca_path.empty? %>
 ;newrelic.daemon.ssl_ca_path = ""
 <% else %>
 newrelic.daemon.ssl_ca_path = "<%= @resource.daemon_ssl_ca_path %>"
 <% end %>
-<% if @resource.daemon_ssl_ca_bundle.nil? %>
+<% unless @resource.daemon_ssl_ca_bundle && !@resource.daemon_ssl_ca_bundle.empty? %>
 ;newrelic.daemon.ssl_ca_bundle = ""
 <% else %>
 newrelic.daemon.ssl_ca_bundle = "<%= @resource.daemon_ssl_ca_bundle %>"
@@ -238,7 +238,7 @@ newrelic.daemon.ssl_ca_bundle = "<%= @resource.daemon_ssl_ca_bundle %>"
 ;             user:password@hostname
 ;             user:password@hostname:port
 ;
-<% if @resource.daemon_proxy.nil? %>
+<% unless @resource.daemon_proxy && !@resource.daemon_proxy.empty? %>
 ;newrelic.daemon.proxy = ""
 <% else %>
 newrelic.daemon.proxy = "<%= @resource.daemon_proxy %>"
@@ -253,7 +253,7 @@ newrelic.daemon.proxy = "<%= @resource.daemon_proxy %>"
 ;          (PID) in. This file is used by the daemon startup and shutdown
 ;          script to determine whether or not the daemon is already running.
 ;
-<% if @resource.daemon_pidfile.nil? %>
+<% unless @resource.daemon_pidfile && !@resource.daemon_pidfile.empty? %>
 ;newrelic.daemon.pidfile = ""
 <% else %>
 newrelic.daemon.pidfile = "<%= @resource.daemon_pidfile %>"
@@ -269,7 +269,7 @@ newrelic.daemon.pidfile = "<%= @resource.daemon_pidfile %>"
 ;          filesystem, the default daemon location is
 ;          /opt/newrelic/bin/newrelic-daemon.
 ;
-<% if @resource.daemon_location.nil? %>
+<% unless @resource.daemon_location && !@resource.daemon_location.empty? %>
 ;newrelic.daemon.location = "/usr/bin/newrelic-daemon"
 <% else %>
 newrelic.daemon.location = "<%= @resource.daemon_location %>"
@@ -287,7 +287,7 @@ newrelic.daemon.location = "<%= @resource.daemon_location %>"
 ;          circumstances, and then only on instruction from a New Relic sales
 ;          person or support staff member.
 ;
-<% if @resource.daemon_collector_host.nil? %>
+<% unless @resource.daemon_collector_host && !@resource.daemon_collector_host.empty? %>
 ;newrelic.daemon.collector_host = "collector.newrelic.com"
 <% else %>
 newrelic.daemon.collector_host = "<%= @resource.daemon_collector_host %>"
@@ -307,7 +307,7 @@ newrelic.daemon.collector_host = "<%= @resource.daemon_collector_host %>"
 ;          2 - only CLI agents can start the daemon
 ;          3 - the agent will never start the daemon
 ;
-<% if @resource.daemon_dont_launch.nil? %>
+<% unless @resource.daemon_dont_launch && !@resource.daemon_dont_launch.empty? %>
 ;newrelic.daemon.dont_launch = 0
 <% else %>
 newrelic.daemon.dont_launch = <%= @resource.daemon_dont_launch %>
@@ -326,7 +326,7 @@ newrelic.daemon.dont_launch = <%= @resource.daemon_dont_launch %>
 ;          parameters are simply used for parameters without sensitive data but
 ;          that are meaningful to each transaction then you can enable this.
 ;
-<% if @resource.capture_params.nil? %>
+<% unless @resource.capture_params && !@resource.capture_params.empty? %>
 ;newrelic.capture_params = false
 <% else %>
 newrelic.capture_params = <%= @resource.capture_params %>
@@ -340,7 +340,7 @@ newrelic.capture_params = <%= @resource.capture_params %>
 ;          capturing is enabled above. You can use this to filter out sensitive
 ;          user data that may appear as a URL parameter.
 ;
-<% if @resource.ignored_params.nil? %>
+<% unless @resource.ignored_params && !@resource.ignored_params.empty? %>
 ;newrelic.ignored_params = ""
 <% else %>
 newrelic.ignored_params = "<%= @resource.ignored_params %>"
@@ -356,7 +356,7 @@ newrelic.ignored_params = "<%= @resource.ignored_params %>"
 ;          Please also note that your New Relic subscription level may force
 ;          this to be disabled regardless of any value you set for it.
 ;
-<% if @resource.error_collector_enable.nil? %>
+<% unless @resource.error_collector_enable && !@resource.error_collector_enable.empty? %>
 ;newrelic.error_collector.enable = true
 <% else %>
 newrelic.error_collector.enable = <%= @resource.error_collector_enable %>
@@ -373,7 +373,7 @@ newrelic.error_collector.enable = <%= @resource.error_collector_enable %>
 ;          collection. This is only objeyed if the error collector is enabled
 ;          above and the account subscription level permits error trapping.
 ;
-<% if @resource.error_collector_record_database_errors.nil? %>
+<% unless @resource.error_collector_record_database_errors && !@resource.error_collector_record_database_errors.empty? %>
 ;newrelic.error_collector.record_database_errors = false
 <% else %>
 newrelic.error_collector.record_database_errors = <%= @resource.error_collector_record_database_errors %>
@@ -388,7 +388,7 @@ newrelic.error_collector.record_database_errors = <%= @resource.error_collector_
 ;          notice an error, if this is set to true then assign the highest
 ;          priority to such errors.
 ;
-<% if @resource.error_collector_prioritize_api_errors.nil? %>
+<% unless @resource.error_collector_prioritize_api_errors && !@resource.error_collector_prioritize_api_errors.empty? %>
 ;newrelic.error_collector.prioritize_api_errors = false
 <% else %>
 newrelic.error_collector.prioritize_api_errors = <%= @resource.error_collector_prioritize_api_errors %>
@@ -403,7 +403,7 @@ newrelic.error_collector.prioritize_api_errors = <%= @resource.error_collector_p
 ;          When enabled will cause the agent to insert a header and a footer
 ;          in HTML output that will time the actual end-user experience.
 ;
-<% if @resource.browser_monitoring_auto_instrument.nil? %>
+<% unless @resource.browser_monitoring_auto_instrument && !@resource.browser_monitoring_auto_instrument.empty? %>
 ;newrelic.browser_monitoring.auto_instrument = true
 <% else %>
 newrelic.browser_monitoring.auto_instrument = <%= @resource.browser_monitoring_auto_instrument %>
@@ -423,7 +423,7 @@ newrelic.browser_monitoring.auto_instrument = <%= @resource.browser_monitoring_a
 ;          note that TT's may be disabled by your account subscription level
 ;          regardless of what you set here.
 ;
-<% if @resource.transaction_tracer_enable.nil? %>
+<% unless @resource.transaction_tracer_enable && !@resource.transaction_tracer_enable.empty? %>
 ;newrelic.transaction_tracer.enable = true
 <% else %>
 newrelic.transaction_tracer.enable = <%= @resource.transaction_tracer_enable %>
@@ -441,7 +441,7 @@ newrelic.transaction_tracer.enable = <%= @resource.transaction_tracer_enable %>
 ;          Thus the threshold changes according to your apdex_t setting. This
 ;          is the default.
 ;
-<% if @resource.transaction_tracer_threshold.nil? %>
+<% unless @resource.transaction_tracer_threshold && !@resource.transaction_tracer_threshold.empty? %>
 ;newrelic.transaction_tracer.threshold = "apdex_f"
 <% else %>
 newrelic.transaction_tracer.threshold = "<%= @resource.transaction_tracer_threshold %>"
@@ -465,7 +465,7 @@ newrelic.transaction_tracer.threshold = "<%= @resource.transaction_tracer_thresh
 ;
 ;          In earlier releases of the agent this was known as "top100".
 ;
-<% if @resource.transaction_tracer_detail.nil? %>
+<% unless @resource.transaction_tracer_detail && !@resource.transaction_tracer_detail.empty? %>
 ;newrelic.transaction_tracer.detail = 1
 <% else %>
 newrelic.transaction_tracer.detail = <%= @resource.transaction_tracer_detail %>
@@ -480,7 +480,7 @@ newrelic.transaction_tracer.detail = <%= @resource.transaction_tracer_detail %>
 ;          record the top 10 slowest SQL calls along with a stack trace of
 ;          where the call occurred in your code.
 ;
-<% if @resource.transaction_tracer_slow_sql.nil? %>
+<% unless @resource.transaction_tracer_slow_sql && !@resource.transaction_tracer_slow_sql.empty? %>
 ;newrelic.transaction_tracer.slow_sql = true
 <% else %>
 newrelic.transaction_tracer.slow_sql = <%= @resource.transaction_tracer_slow_sql %>
@@ -494,7 +494,7 @@ newrelic.transaction_tracer.slow_sql = <%= @resource.transaction_tracer_slow_sql
 ; Info   : Sets the threshold above which the New Relic agent will record a
 ;          stack trace for a transaction trace.
 ;
-<% if @resource.transaction_tracer_stack_trace_threshold.nil? %>
+<% unless @resource.transaction_tracer_stack_trace_threshold && !@resource.transaction_tracer_stack_trace_threshold.empty? %>
 ;newrelic.transaction_tracer.stack_trace_threshold = 500
 <% else %>
 newrelic.transaction_tracer.stack_trace_threshold = <%= @resource.transaction_tracer_stack_trace_threshold %>
@@ -511,7 +511,7 @@ newrelic.transaction_tracer.stack_trace_threshold = <%= @resource.transaction_tr
 ;          base for slow SQL. This latter feature may not be active yet, please
 ;          refer to the agent release notes to see when it becomes available.
 ;
-<% if @resource.transaction_tracer_explain_threshold.nil? %>
+<% unless @resource.transaction_tracer_explain_threshold && !@resource.transaction_tracer_explain_threshold.empty? %>
 ;newrelic.transaction_tracer.explain_threshold = 500
 <% else %>
 newrelic.transaction_tracer.explain_threshold = <%= @resource.transaction_tracer_explain_threshold %>
@@ -528,7 +528,7 @@ newrelic.transaction_tracer.explain_threshold = <%= @resource.transaction_tracer
 ;          has considerable security implications as it can expose sensitive
 ;          and private customer data.
 ;
-<% if @resource.transaction_tracer_record_sql.nil? %>
+<% unless @resource.transaction_tracer_record_sql && !@resource.transaction_tracer_record_sql.empty? %>
 ;newrelic.transaction_tracer.record_sql = "obfuscated"
 <% else %>
 newrelic.transaction_tracer.record_sql = "<%= @resource.transaction_tracer_record_sql %>"
@@ -543,7 +543,7 @@ newrelic.transaction_tracer.record_sql = "<%= @resource.transaction_tracer_recor
 ;          set newrelic.transaction_tracer.detail to 0. This can be a comma-
 ;          separated list of function or class method names.
 ;
-<% if @resource.transaction_tracer_custom.nil? %>
+<% unless @resource.transaction_tracer_custom && !@resource.transaction_tracer_custom.empty? %>
 ;newrelic.transaction_tracer.custom = ""
 <% else %>
 newrelic.transaction_tracer.custom = "<%= @resource.transaction_tracer_custom %>"
@@ -562,7 +562,7 @@ newrelic.transaction_tracer.custom = "<%= @resource.transaction_tracer_custom %>
 ;          cakephp, codeigniter, drupal, joomla, kohana, magento, mediawiki,
 ;          symfony, wordpress, yii, zend or no_framework.
 ;
-<% if @resource.framework.nil? %>
+<% unless @resource.framework && !@resource.framework.empty? %>
 ;newrelic.framework = ""
 <% else %>
 newrelic.framework = "<%= @resource.framework %>"
@@ -579,7 +579,7 @@ newrelic.framework = "<%= @resource.framework %>"
 ;          would cause the "/xyz/zy" to be stripped from a URL such as
 ;          "/path/to/foo.php/xyz/zy".
 ;
-<% if @resource.webtransaction_name_remove_trailing_path.nil? %>
+<% unless @resource.webtransaction_name_remove_trailing_path && !@resource.webtransaction_name_remove_trailing_path.empty? %>
 ;newrelic.webtransaction.name.remove_trailing_path = false
 <% else %>
 newrelic.webtransaction.name.remove_trailing_path = <%= @resource.webtransaction_name_remove_trailing_path %>
@@ -599,7 +599,7 @@ newrelic.webtransaction.name.remove_trailing_path = <%= @resource.webtransaction
 ;          and the function names specified here will be used to name the
 ;          transaction.
 ;
-<% if @resource.webtransaction_name_functions.nil? %>
+<% unless @resource.webtransaction_name_functions && !@resource.webtransaction_name_functions.empty? %>
 ;newrelic.webtransaction.name.functions = ""
 <% else %>
 newrelic.webtransaction.name.functions = "<%= @resource.webtransaction_name_functions %>"
@@ -614,7 +614,7 @@ newrelic.webtransaction.name.functions = "<%= @resource.webtransaction_name_func
 ;          names instead of function names. Accepts standard POSIX regular
 ;          expressions.
 ;
-<% if @resource.webtransaction_name_files.nil? %>
+<% unless @resource.webtransaction_name_files && !@resource.webtransaction_name_files.empty? %>
 ;newrelic.webtransaction.name.files = ""
 <% else %>
 newrelic.webtransaction.name.files = "<%= @resource.webtransaction_name_files %>"
@@ -630,7 +630,7 @@ newrelic.webtransaction.name.files = "<%= @resource.webtransaction_name_files %>
 ;          and the response in order to link together web transaction metrics and
 ;          transaction traces between applications.
 ;
-<% if @resource.cross_application_tracer_enable.nil? %>
+<% unless @resource.cross_application_tracer_enable && !@resource.cross_application_tracer_enable.empty? %>
 ;newrelic.cross_application_tracer.enabled = true
 <% else %>
 newrelic.cross_application_tracer.enabled = <%= @resource.cross_application_tracer_enable %>
@@ -651,7 +651,7 @@ newrelic.cross_application_tracer.enabled = <%= @resource.cross_application_trac
 ; Caution: If you change this setting, you must also change the security setting in the New Relic APM user interface.
 ;    If the two settings do not match, then no data will be collected. For more information, see https://docs.newrelic.com/docs/subscriptions/high-security
 ;
-<% if @resource.high_security.nil? %>
+<% unless @resource.high_security && !@resource.high_security.empty? %>
 ;newrelic.high_security = false
 <% else %>
 newrelic.high_security = <%= @resource.high_security %>

--- a/templates/default/agent/python/newrelic.ini.erb
+++ b/templates/default/agent/python/newrelic.ini.erb
@@ -37,7 +37,7 @@ license_key = <%= @license %>
 # application as you would like it to show up in New Relic UI.
 # The UI will then auto-map instances of your application into a
 # entry on your home dashboard page.
-<% if @app_name.nil? %>
+<% unless @app_name && !@app_name.empty? %>
 app_name = Python Application
 <% else %>
 app_name = <%= @app_name %>
@@ -46,7 +46,7 @@ app_name = <%= @app_name %>
 # In order for high security to be enabled, this property must be set to true and the high security property in the New Relic user
 # interface must be enabled. Enabling high security means SSL is turned on, request and message queue parameters are not collected, and
 # SQL cannot be sent to New Relic in its raw form.
-<% unless @high_security.nil? %>
+<% if @high_security && !@high_security.empty? %>
 high_security: <%= @high_security %>
 <% end %>
 
@@ -54,7 +54,7 @@ high_security: <%= @high_security %>
 # application and reports this data to the New Relic UI at
 # newrelic.com. This global switch is normally overridden for
 # each environment below.
-<% if @enabled.nil? %>
+<% unless @enabled && !@enabled.empty? %>
 monitor_mode = true
 <% else %>
 monitor_mode = <%= @enabled %>
@@ -71,7 +71,7 @@ monitor_mode = <%= @enabled %>
 # write out a log file, it is also possible to say "stderr" and
 # output to standard error output. This would normally result in
 # output appearing in your web server log.
-<% if @logfile.nil? %>
+<% unless @logfile && !@logfile.empty? %>
 log_file = /tmp/newrelic-python-agent.log
 <% else %>
 log_file = <%= @logfile %>
@@ -86,7 +86,7 @@ log_file = <%= @logfile %>
 # of information very quickly, so it is best not to keep the
 # agent at this level for longer than it takes to reproduce the
 # problem you are experiencing.
-<% if @loglevel.nil? %>
+<% unless @loglevel && !@loglevel.empty? %>
 log_level = info
 <% else %>
 log_level = <%= @loglevel %>
@@ -99,7 +99,7 @@ log_level = <%= @loglevel %>
 # perform the encryption involved in SSL communication, but this
 # work is done asynchronously to the threads that process your
 # application code, so it should not impact response times.
-<% if @daemon_ssl.nil? %>
+<% unless @daemon_ssl && !@daemon_ssl.empty? %>
 ssl = false
 <% else %>
 ssl = <%= @daemon_ssl %>
@@ -123,7 +123,7 @@ ssl = <%= @daemon_ssl %>
 # URL and send it as the request parameters for display in the
 # UI. When "true", it is still possible to exclude specific
 # values from being captured using the "ignored_params" setting.
-<% if @capture_params.nil? %>
+<% unless @capture_params && !@capture_params.empty? %>
 capture_params = false
 <% else %>
 capture_params = <%= @capture_params %>
@@ -132,7 +132,7 @@ capture_params = <%= @capture_params %>
 # Space separated list of variables that should be removed from
 # the query string captured for display as the request
 # parameters in the UI.
-<% if @ignored_params.nil? %>
+<% unless @ignored_params && !@ignored_params.empty? %>
 ignored_params =
 <% else %>
 ignored_params = <%= @ignored_params %>
@@ -142,7 +142,7 @@ ignored_params = <%= @ignored_params %>
 # transactions and sends this to the UI on a periodic basis. The
 # transaction tracer is enabled by default. Set this to "false"
 # to turn it off.
-<% if @transaction_tracer_enable.nil? %>
+<% unless @transaction_tracer_enable && !@transaction_tracer_enable.empty? %>
 transaction_tracer.enabled = true
 <% else %>
 transaction_tracer.enabled = <%= @transaction_tracer_enable %>
@@ -154,7 +154,7 @@ transaction_tracer.enabled = <%= @transaction_tracer_enable %>
 # the UI. Valid values are any positive float value, or (default)
 # "apdex_f", which will use the threshold for a dissatisfying
 # Apdex controller action - four times the Apdex T value.
-<% if @transaction_tracer_threshold.nil? %>
+<% unless @transaction_tracer_threshold && !@transaction_tracer_threshold.empty? %>
 transaction_tracer.transaction_threshold = apdex_f
 <% else %>
 transaction_tracer.transaction_threshold = "<%= @transaction_tracer_threshold %>"
@@ -165,7 +165,7 @@ transaction_tracer.transaction_threshold = "<%= @transaction_tracer_threshold %>
 # which sends no SQL, "raw" which sends the SQL statement in its
 # original form, and "obfuscated", which strips out numeric and
 # string literals.
-<% if @transaction_tracer_record_sql.nil? %>
+<% unless @transaction_tracer_record_sql && !@transaction_tracer_record_sql.empty? %>
 transaction_tracer.record_sql = obfuscated
 <% else %>
 transaction_tracer.record_sql = <%= @transaction_tracer_record_sql %>
@@ -176,7 +176,7 @@ transaction_tracer.record_sql = <%= @transaction_tracer_record_sql %>
 # threshold, then capture and send to the UI the current stack
 # trace. This is helpful for pinpointing where long SQL calls
 # originate from in an application.
-<% if @transaction_tracer_stack_trace_threshold.nil? %>
+<% unless @transaction_tracer_stack_trace_threshold && !@transaction_tracer_stack_trace_threshold.empty? %>
 transaction_tracer.stack_trace_threshold = 0.5
 <% else %>
 transaction_tracer.stack_trace_threshold = <%= @transaction_tracer_stack_trace_threshold %>
@@ -185,7 +185,7 @@ transaction_tracer.stack_trace_threshold = <%= @transaction_tracer_stack_trace_t
 # Determines whether the agent will capture query plans for slow
 # SQL queries. Only supported in MySQL and PostgreSQL. Set this
 # to "false" to turn it off.
-<% if @transaction_tracer_slow_sql.nil? %>
+<% unless @transaction_tracer_slow_sql && !@transaction_tracer_slow_sql.empty? %>
 transaction_tracer.explain_enabled = true
 <% else %>
 transaction_tracer.explain_enabled = <%= @transaction_tracer_slow_sql %>
@@ -194,7 +194,7 @@ transaction_tracer.explain_enabled = <%= @transaction_tracer_slow_sql %>
 # Threshold for query execution time below which query plans
 # will not not be captured. Relevant only when "explain_enabled"
 # is true.
-<% if @transaction_tracer_explain_threshold.nil? %>
+<% unless @transaction_tracer_explain_threshold && !@transaction_tracer_explain_threshold.empty? %>
 transaction_tracer.explain_threshold = 0.5
 <% else %>
 transaction_tracer.explain_threshold = <%= @transaction_tracer_explain_threshold %>
@@ -209,7 +209,7 @@ transaction_tracer.function_trace =
 # exceptions or logged exceptions and sends them to UI for
 # viewing. The error collector is enabled by default. Set this
 # to "false" to turn it off.
-<% if @error_collector_enable.nil? %>
+<% unless @error_collector_enable && !@error_collector_enable.empty? %>
 error_collector.enabled = true
 <% else %>
 error_collector.enabled = <%= @error_collector_enable %>
@@ -218,7 +218,7 @@ error_collector.enabled = <%= @error_collector_enable %>
 # To stop specific errors from reporting to the UI, set this to
 # a space separated list of the Python exception type names to
 # ignore. The exception name should be of the form 'module:class'.
-<% if @error_collector_ignore_errors.nil? %>
+<% unless @error_collector_ignore_errors && !@error_collector_ignore_errors.empty? %>
 error_collector.ignore_errors =
 <% else %>
 error_collector.ignore_errors = <%= @error_collector_ignore_errors %>
@@ -228,7 +228,7 @@ error_collector.ignore_errors = <%= @error_collector_ignore_errors %>
 # For those Python web frameworks that are supported, this
 # setting enables the auto-insertion of the browser monitoring
 # JavaScript fragments.
-<% if @browser_monitoring_auto_instrument.nil? %>
+<% unless @browser_monitoring_auto_instrument && !@browser_monitoring_auto_instrument.empty? %>
 browser_monitoring.auto_instrument = true
 <% else %>
 browser_monitoring.auto_instrument = <%= @browser_monitoring_auto_instrument %>
@@ -239,7 +239,7 @@ browser_monitoring.auto_instrument = <%= @browser_monitoring_auto_instrument %>
 # capture a snapshot of the call stack for each active thread in
 # the application to construct a statistically representative
 # call tree.
-<% if @thread_profiler_enable.nil? %>
+<% unless @thread_profiler_enable && !@thread_profiler_enable.empty? %>
 thread_profiler.enabled = true
 <% else %>
 thread_profiler.enabled = <%= @thread_profiler_enable %>
@@ -249,13 +249,13 @@ thread_profiler.enabled = <%= @thread_profiler_enable %>
 # The cross application tracer inserts HTTP headers into outbound requests
 # and the response in order to link together web transaction metrics and
 # transaction traces between applications.
-<% if @cross_application_tracer_enable.nil? %>
+<% unless @cross_application_tracer_enable && !@cross_application_tracer_enable.empty? %>
 # cross_application_tracer.enabled = true
 <% else %>
 cross_application_tracer.enabled = <%= @cross_application_tracer_enable %>
 <% end %>
 
-<% unless @feature_flag.nil? %>
+<% if @feature_flag && !@feature_flag.empty? %>
 # Feature flag
 # eg. use for improved Tornado instrumentation
 # (https://docs.newrelic.com/docs/release-notes/agent-release-notes/python-release-notes/python-agent-232028)

--- a/templates/default/agent/server_monitor/nrsysmond.cfg.erb
+++ b/templates/default/agent/server_monitor/nrsysmond.cfg.erb
@@ -32,7 +32,7 @@ license_key=<%= @resource.license %>
 # Default: error
 # Note   : Can also be set with the -d command line option.
 #
-<% if @resource.loglevel.nil? %>
+<% unless @resource.loglevel && !@resource.loglevel.empty? %>
 loglevel=info
 <% else %>
 loglevel=<%= @resource.loglevel %>
@@ -46,7 +46,7 @@ loglevel=<%= @resource.loglevel %>
 # Default: none. However it is highly recommended you set a value for this.
 # Note   : Can also be set with the -l command line option.
 #
-<% if @resource.logfile.nil? %>
+<% unless @resource.logfile && !@resource.logfile.empty? %>
 logfile=/var/log/newrelic/nrsysmond.log
 <% else %>
 logfile=<%= @resource.logfile %>
@@ -63,7 +63,7 @@ logfile=<%= @resource.logfile %>
 #            fred:secret@proxy.mydomain.com:8181
 # Default: none (use a direct connection)
 #
-<% if @resource.proxy.nil? %>
+<% unless @resource.proxy && !@resource.proxy.empty? %>
 #proxy=
 <% else %>
 proxy=<%= @resource.proxy %>
@@ -77,7 +77,7 @@ proxy=<%= @resource.proxy %>
 #          the SSL certificates settings below.
 # Default: false
 #
-<% if @resource.ssl.nil? %>
+<% unless @resource.ssl && !@resource.ssl.empty? %>
 #ssl=false
 <% else %>
 ssl=<%= @resource.ssl %>
@@ -94,7 +94,7 @@ ssl=<%= @resource.ssl %>
 #          /etc/pki/tls/certs/ca-bundle.crt
 # Note   : Can also be set with the -b command line option.
 #
-<% if @resource.ssl_ca_bundle.nil? %>
+<% unless @resource.ssl_ca_bundle && !@resource.ssl_ca_bundle.empty? %>
 #ssl_ca_bundle=/path/to/your/bundle.crt
 <% else %>
 ssl_ca_bundle=<%= @resource.ssl_ca_bundle %>
@@ -108,7 +108,7 @@ ssl_ca_bundle=<%= @resource.ssl_ca_bundle %>
 # Default: /etc/ssl/certs
 # Note   : Can also be set with the -S command line option.
 #
-<% if @resource.ssl_ca_path.nil? %>
+<% unless @resource.ssl_ca_path && !@resource.ssl_ca_path.empty? %>
 #ssl_ca_path=/etc/ssl/certs
 <% else %>
 ssl_ca_path=<%= @resource.ssl_ca_path %>
@@ -124,7 +124,7 @@ ssl_ca_path=<%= @resource.ssl_ca_path %>
 # Default: Whatever the system calls the host.
 # Note   : Can also be set with the -n command line option.
 #
-<% if @resource.hostname.nil? %>
+<% unless @resource.hostname && !@resource.hostname.empty? %>
 #hostname=
 <% else %>
 hostname=<%= @resource.hostname %>
@@ -138,7 +138,7 @@ hostname=<%= @resource.hostname %>
 #          a semicolon delimited string of colon-separated pairs;
 #          for example, labels=Server:One;Data Center:Primary;.
 # Default: nil
-<% if @resource.labels.nil? %>
+<% unless @resource.labels && !@resource.labels.empty? %>
 #labels=
 <% else %>
 labels=<%= @resource.labels %>
@@ -153,7 +153,7 @@ labels=<%= @resource.labels %>
 # Default: /tmp/nrsysmond.pid
 # Note   : Can also be set with the -p command line option.
 #
-<% if @resource.pidfile.nil? %>
+<% unless @resource.pidfile && !@resource.pidfile.empty? %>
 #pidfile=/var/run/newrelic/nrsysmond.pid
 <% else %>
 pidfile=<%= @resource.pidfile %>
@@ -168,7 +168,7 @@ pidfile=<%= @resource.pidfile %>
 #          if SSL is enabled. If the port is omitted the default value is used.
 # Default: collector.newrelic.com
 #
-<% if @resource.collector_host.nil? %>
+<% unless @resource.collector_host && !@resource.collector_host.empty? %>
 #collector_host=collector.newrelic.com
 <% else %>
 collector_host=<%= @resource.collector_host %>
@@ -186,7 +186,7 @@ collector_host=<%= @resource.collector_host %>
 #          once the original connection has been made. The value is in seconds.
 # Default: 30
 #
-<% if @resource.timeout.nil? %>
+<% unless @resource.timeout && !@resource.timeout.empty? %>
 #timeout=30
 <% else %>
 timeout=<%= @resource.timeout %>


### PR DESCRIPTION
- It's much better to use 'true' and 'false' over true and false, as there's no guarantee that `true.to_s == 'true'`. I changed around the resources to accept TrueClass, FalseClass, or a String, but they will always convert whichever they get to Strings. Then you aren't relying on ruby to coerce booleans into strings and hope you get "true" and "false" (maybe one day you will get "True").

- Many `if something.nil?` checks were replaced with `unless something && !something.empty?`. This prevents false and the empty string from being handed to various templates and logic, since the empty string is not nill.

- NewRelic.to_boolean was called in a few places, but it wasn't in the NewRelic module, it was in the helpers module (so it failed to compile). I've moved it into the NewRelic module.

- Removed `param value if value` from resource invocations. The providers all know how to handle nil and false, so there's no need to repeat the conditional so much.

- One boolean value was still being passed a String in a recipe. Fixes https://github.com/escapestudios-cookbooks/newrelic/issues/179.