### PR TITLE
Fixed NodeJS config capitalization, Java agent provider File class namespace and agent version remote_file logic.

### DIFF
--- a/attributes/nodejs_agent.rb
+++ b/attributes/nodejs_agent.rb
@@ -9,4 +9,4 @@ default['newrelic']['nodejs_agent']['agent_action'] = :install
 default['newrelic']['nodejs_agent']['apps'] = []
 default['newrelic']['nodejs_agent']['template']['cookbook'] = 'newrelic'
 default['newrelic']['nodejs_agent']['template']['source'] = 'agent/nodejs/newrelic.js.erb'
-default['newrelic']['nodejs_agent']['default_app_log_level'] = 'INFO'
+default['newrelic']['nodejs_agent']['default_app_log_level'] = 'info'

--- a/providers/agent_java.rb
+++ b/providers/agent_java.rb
@@ -53,7 +53,7 @@ def agent_jar
   agent_jar = "#{new_resource.install_dir}/#{jar_file}"
   https_download = "https://download.newrelic.com/newrelic/java-agent/newrelic-agent/#{version}/#{jar_file}"
 
-  remote_file 'newrelic.jar' do
+  remote_file agent_jar do
     source https_download
     owner 'root'
     group 'root'
@@ -78,13 +78,13 @@ end
 
 def allow_app_group_write_to_log_file_path
   path = new_resource.logfile_path
-  until path.nil? || path.empty? || path == File::SEPARATOR
+  until path.nil? || path.empty? || path == ::File::SEPARATOR
     directory path do
       group new_resource.app_group
       mode 0775
       action :create
     end
-    path = File.dirname(path)
+    path = ::File.dirname(path)
   end
 end
 

--- a/spec/unit/agent_java_spec.rb
+++ b/spec/unit/agent_java_spec.rb
@@ -21,7 +21,7 @@ describe 'newrelic_lwrp_test::agent_java' do
     end
 
     it 'creates newrelic.jar' do
-      expect(chef_run).to create_remote_file('newrelic.jar')
+      expect(chef_run).to create_remote_file(/\/opt\/newrelic\/java\/newrelic.+\.jar/)
     end
 
     it 'creates newrelic yml config template from newrelic.yml.erb' do


### PR DESCRIPTION
Title is pretty self-explanatory.

* Fixed the NodeJS cookbook default attribute to avoid a nasty capitalization issue with the New Relic agent (looks like this was already fixed/honored in the corresponding resource provider.
* Java agent provider was throwing a `uninitialized constant Chef::Provider::File::SEPARATOR` error due to a missing Ruby namespace resolution operator. Fixed that.
* Java agent provider was not using it's own code for setting the proper file path and name of the Java agent JAR. Fixed! Also updated the ChefSpec unit test to keep coverage with this change.