### PR TITLE
Fixed NodeJS config capitalization, Java agent provider File class namespace and agent version remote_file logic.

### DIFF
--- a/attributes/java_agent.rb
+++ b/attributes/java_agent.rb
@@ -6,7 +6,7 @@
 #
 
 default['newrelic']['java_agent']['version'] = 'latest'
-default['newrelic']['java_agent']['install_dir'] = '/opt/newrelic/java'
+default['newrelic']['java_agent']['install_dir'] = '/opt'
 default['newrelic']['java_agent']['app_user'] = 'newrelic'
 default['newrelic']['java_agent']['app_group'] = 'newrelic'
 default['newrelic']['java_agent']['audit_mode'] = false

--- a/attributes/nodejs_agent.rb
+++ b/attributes/nodejs_agent.rb
@@ -9,4 +9,4 @@ default['newrelic']['nodejs_agent']['agent_action'] = :install
 default['newrelic']['nodejs_agent']['apps'] = []
 default['newrelic']['nodejs_agent']['template']['cookbook'] = 'newrelic'
 default['newrelic']['nodejs_agent']['template']['source'] = 'agent/nodejs/newrelic.js.erb'
-default['newrelic']['nodejs_agent']['default_app_log_level'] = 'INFO'
+default['newrelic']['nodejs_agent']['default_app_log_level'] = 'info'

--- a/providers/agent_java.rb
+++ b/providers/agent_java.rb
@@ -27,7 +27,7 @@ action :remove do
 end
 
 def create_install_directory
-  directory new_resource.install_dir do
+  directory "#{new_resource.install_dir}/newrelic" do
     owner new_resource.app_user
     group new_resource.app_group
     recursive true
@@ -47,10 +47,10 @@ def agent_jar
     jar_file = url_content.split(/\W+jar/).first.to_s.split('\\"').last + '.jar'
   else
     version = new_resource.version
-    jar_file = 'newrelic.jar'
+    jar_file = 'newrelic-agent-#{version}.jar'
   end
 
-  agent_jar = "#{new_resource.install_dir}/#{jar_file}"
+  agent_jar = "#{new_resource.install_dir}/newrelic/newrelic.jar"
   https_download = "https://download.newrelic.com/newrelic/java-agent/newrelic-agent/#{version}/#{jar_file}"
 
   remote_file agent_jar do
@@ -63,7 +63,7 @@ def agent_jar
 end
 
 def generate_agent_config
-  template "#{new_resource.install_dir}/newrelic.yml" do
+  template "#{new_resource.install_dir}/newrelic/newrelic.yml" do
     cookbook new_resource.template_cookbook
     source new_resource.template_source
     owner 'root'
@@ -96,7 +96,8 @@ def install_newrelic
     app_location = new_resource.app_location
   end
   execute "newrelic_install_#{jar_file}" do
-    command "sudo java -jar #{jar_file} -s #{app_location} install"
+    command "sudo java -jar #{jar_file} install"
+    cwd "#{new_resource.install_dir}/newrelic"
     only_if { new_resource.execute_agent_action == true }
   end
 end

--- a/providers/agent_java.rb
+++ b/providers/agent_java.rb
@@ -77,7 +77,7 @@ def generate_agent_config
 end
 
 def allow_app_group_write_to_log_file_path
-  path = ((::File.basename(new_resource.logfile_path).include? ".") ? ::File.dirname(new_resource.logfile_path) : new_resource.logfile_path)
+  path = new_resource.logfile_path
   until path.nil? || path.empty? || path == ::File::SEPARATOR
     directory path do
       group new_resource.app_group

--- a/providers/agent_java.rb
+++ b/providers/agent_java.rb
@@ -77,7 +77,7 @@ def generate_agent_config
 end
 
 def allow_app_group_write_to_log_file_path
-  path = new_resource.logfile_path
+  path = ((::File.basename(new_resource.logfile_path).include? ".") ? ::File.dirname(new_resource.logfile_path) : new_resource.logfile_path)
   until path.nil? || path.empty? || path == ::File::SEPARATOR
     directory path do
       group new_resource.app_group

--- a/providers/agent_java.rb
+++ b/providers/agent_java.rb
@@ -53,7 +53,7 @@ def agent_jar
   agent_jar = "#{new_resource.install_dir}/#{jar_file}"
   https_download = "https://download.newrelic.com/newrelic/java-agent/newrelic-agent/#{version}/#{jar_file}"
 
-  remote_file 'newrelic.jar' do
+  remote_file agent_jar do
     source https_download
     owner 'root'
     group 'root'
@@ -78,13 +78,13 @@ end
 
 def allow_app_group_write_to_log_file_path
   path = new_resource.logfile_path
-  until path.nil? || path.empty? || path == File::SEPARATOR
+  until path.nil? || path.empty? || path == ::File::SEPARATOR
     directory path do
       group new_resource.app_group
       mode 0775
       action :create
     end
-    path = File.dirname(path)
+    path = ::File.dirname(path)
   end
 end
 

--- a/recipes/java_agent.rb
+++ b/recipes/java_agent.rb
@@ -15,10 +15,10 @@ newrelic_agent_java 'Install' do
   enabled node['newrelic']['application_monitoring']['enabled'] unless node['newrelic']['application_monitoring']['enabled'].nil?
   app_name node['newrelic']['application_monitoring']['app_name'] unless node['newrelic']['application_monitoring']['app_name'].nil?
   high_security NewRelic.to_boolean(node['newrelic']['application_monitoring']['high_security']) unless node['newrelic']['application_monitoring']['high_security'].nil?
-  owner node['newrelic']['java_agent']['app_user'] unless node['newrelic']['java_agent']['app_user'].nil?
-  group node['newrelic']['java_agent']['app_group'] unless node['newrelic']['java_agent']['app_group'].nil?
-  logfile node['newrelic']['application_monitoring']['logfile'] unless node['newrelic']['application_monitoring']['logfile'].nil?
-  logfile_path node['newrelic']['application_monitoring']['logfile_path'] unless node['newrelic']['application_monitoring']['logfile_path'].nil?
+  app_user node['newrelic']['java_agent']['app_user'] unless node['newrelic']['java_agent']['app_user'].nil?
+  app_group node['newrelic']['java_agent']['app_group'] unless node['newrelic']['java_agent']['app_group'].nil?
+  logfile ::File.basename(node['newrelic']['application_monitoring']['logfile']) unless node['newrelic']['application_monitoring']['logfile'].nil?
+  logfile_path (node['newrelic']['application_monitoring']['logfile'].nil? ? node['newrelic']['application_monitoring']['logfile_path'] : ::File.dirname(node['newrelic']['application_monitoring']['logfile'])) unless !node['newrelic']['application_monitoring']['logfile_path'].nil?
   loglevel node['newrelic']['application_monitoring']['loglevel'] unless node['newrelic']['application_monitoring']['loglevel'].nil?
   audit_mode node['newrelic']['java_agent']['audit_mode'] unless node['newrelic']['java_agent']['audit_mode'].nil?
   log_file_count node['newrelic']['java_agent']['log_file_count'] unless node['newrelic']['java_agent']['log_file_count'].nil?

--- a/recipes/java_agent.rb
+++ b/recipes/java_agent.rb
@@ -8,6 +8,8 @@
 newrelic_agent_java 'Install' do
   license NewRelic.application_monitoring_license(node)
   agent_type 'java'
+  version node['newrelic']['java_agent']['version'] unless node['newrelic']['java_agent']['version'].nil?
+  install_dir node['newrelic']['java_agent']['install_dir'] unless node['newrelic']['java_agent']['install_dir'].nil?
   template_cookbook node['newrelic']['java_agent']['template_cookbook'] unless node['newrelic']['java_agent']['template_cookbook'].nil?
   template_source node['newrelic']['java_agent']['template_source'] unless node['newrelic']['java_agent']['template_source'].nil?
   enabled node['newrelic']['application_monitoring']['enabled'] unless node['newrelic']['application_monitoring']['enabled'].nil?

--- a/recipes/nodejs_agent.rb
+++ b/recipes/nodejs_agent.rb
@@ -13,5 +13,7 @@ node['newrelic']['nodejs_agent']['apps'].each do |nodeapp|
     app_name nodeapp['app_name'] unless nodeapp['app_name'].nil?
     app_log_level nodeapp['app_log_level'] unless nodeapp['app_log_level'].nil?
     app_log_filepath nodeapp['app_log_filepath'] unless nodeapp['app_log_filepath'].nil?
+    capture_params nodeapp['capture_params'] unless nodeapp['capture_params'].nil?
+    ignored_params nodeapp['ignored_params'] unless nodeapp['ignored_params'].nil?
   end
 end

--- a/resources/agent_nodejs.rb
+++ b/resources/agent_nodejs.rb
@@ -18,3 +18,5 @@ attribute :source, :kind_of => String, :default => 'agent/nodejs/newrelic.js.erb
 attribute :enabled, :kind_of => [TrueClass, FalseClass], :default => true
 attribute :app_log_level, :kind_of => String, :default => 'info'
 attribute :app_log_filepath, :kind_of => String, :default => nil
+attribute :capture_params, :kind_of => String, :default => nil
+attribute :ignored_params, :kind_of => String, :default => nil

--- a/spec/unit/agent_java_spec.rb
+++ b/spec/unit/agent_java_spec.rb
@@ -17,15 +17,15 @@ describe 'newrelic_lwrp_test::agent_java' do
     end
 
     it 'creates install_dir' do
-      expect(chef_run).to create_directory('/opt/newrelic/java')
+      expect(chef_run).to create_directory('/opt/newrelic')
     end
 
     it 'creates newrelic.jar' do
-      expect(chef_run).to create_remote_file(%r{\/opt\/newrelic\/java\/newrelic.+\.jar})
+      expect(chef_run).to create_remote_file('/opt/newrelic/newrelic.jar')
     end
 
     it 'creates newrelic yml config template from newrelic.yml.erb' do
-      expect(chef_run).to render_file('/opt/newrelic/java/newrelic.yml').with_content('0000ffff0000ffff0000ffff0000ffff0000ffff')
+      expect(chef_run).to render_file('/opt/newrelic/newrelic.yml').with_content('0000ffff0000ffff0000ffff0000ffff0000ffff')
     end
 
     it 'execute newrelic_install_newrelic.jar' do

--- a/spec/unit/agent_java_spec.rb
+++ b/spec/unit/agent_java_spec.rb
@@ -21,7 +21,7 @@ describe 'newrelic_lwrp_test::agent_java' do
     end
 
     it 'creates newrelic.jar' do
-      expect(chef_run).to create_remote_file(/\/opt\/newrelic\/java\/newrelic.+\.jar/)
+      expect(chef_run).to create_remote_file(%r{\/opt\/newrelic\/java\/newrelic.+\.jar})
     end
 
     it 'creates newrelic yml config template from newrelic.yml.erb' do

--- a/spec/unit/agent_java_spec.rb
+++ b/spec/unit/agent_java_spec.rb
@@ -21,7 +21,7 @@ describe 'newrelic_lwrp_test::agent_java' do
     end
 
     it 'creates newrelic.jar' do
-      expect(chef_run).to create_remote_file('newrelic.jar')
+      expect(chef_run).to create_remote_file(/\/opt\/newrelic\/java\/newrelic.+\.jar/)
     end
 
     it 'creates newrelic yml config template from newrelic.yml.erb' do

--- a/templates/default/agent/nodejs/newrelic.js.erb
+++ b/templates/default/agent/nodejs/newrelic.js.erb
@@ -28,6 +28,23 @@ exports.config = {
         <% else -%>
 
         <% end -%>
-    }
+    }<% unless @resource.capture_params.nil? -%>,
+    /**
+     * Whether to capture request parameters in the request URL for slow transaction
+     * traces and error traces.
+     */
+    capture_params: <%= @resource.capture_params %>
+    <% else -%>
 
+    <% end -%><% unless @resource.ignored_params.nil? -%>,
+    /**
+     * Comma-delimited list of parameter names to ignore that otherwise would be
+     * captured from request URLs in slow transaction traces and error traces. For
+     * example, some parameters may contain sensitive values you do not want being
+     * sent out of your application.
+     */
+    ignored_params: <%= @resource.ignored_params.split(',') %>
+    <% else -%>
+
+    <% end -%>
 };


### PR DESCRIPTION
Title is pretty self-explanatory.

* Fixed the NodeJS cookbook default attribute to avoid a nasty capitalization issue with the New Relic agent (looks like this was already fixed/honored in the corresponding resource provider.
* Java agent provider was throwing a `uninitialized constant Chef::Provider::File::SEPARATOR` error due to a missing Ruby namespace resolution operator. Fixed that.
* Java agent provider was not using it's own code for setting the proper file path and name of the Java agent JAR. Fixed! Also updated the ChefSpec unit test to keep coverage with this change.