### PR TITLE
Add matcher methods for resources

### DIFF
--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -1,4 +1,12 @@
 if defined?(ChefSpec)
+  ChefSpec.define_matcher :newrelic_server_monitor
+  ChefSpec.define_matcher :newrelic_agent_php
+  ChefSpec.define_matcher :newrelic_agent_java
+  ChefSpec.define_matcher :newrelic_agent_ruby
+  ChefSpec.define_matcher :newrelic_agent_dotnet
+  ChefSpec.define_matcher :newrelic_agent_python
+  ChefSpec.define_matcher :newrelic_agent_nodejs
+
   def install_newrelic_server_monitor(resource_name)
     ChefSpec::Matchers::ResourceMatcher.new(:newrelic_server_monitor, :install, resource_name)
   end


### PR DESCRIPTION
This is helpful while asserting against custom resource notifications.  For example:

 ```
describe 'Install' do
    subject { chef_run.newrelic_agent_java('Install') }
    it { is_expected.to notify('service[myservice]').to(:restart).delayed }
  end
end
```



Reference:  https://github.com/sethvargo/chefspec#writing-custom-matchers