### PR TITLE
only stop the newrelic-daemon if it has not been run by the agent

### DIFF
--- a/providers/agent_php.rb
+++ b/providers/agent_php.rb
@@ -136,8 +136,10 @@ def startup_mode_config
   when 'agent'
     # agent startup mode
     # ensure that the daemon isn't currently running
+    # only stop the daemon if it has not been run by the agent (with a newrelic.cfg)
     service 'newrelic-daemon' do
       action [:disable, :stop] # stops the service if it's running and disables it from starting at system boot time
+      only_if { ::File.exist?('/etc/newrelic/newrelic.cfg') }
     end
     # ensure that the file /etc/newrelic/newrelic.cfg does not exist if it does, move it aside (or remove it)
     execute 'newrelic-backup-cfg' do


### PR DESCRIPTION
It should fix #167 #58.
The first Chef run the newrelic.cf will be there.
We stop and disable the daemon.
We then move the newrelic.cfg
The next Chef run the newrelic.cfg file will not be there so it will no stop the daemon. 
If the ini file has been changed it will reload `new_resource.service_name` and apply the change.

It should prevent the recipe to always stop the daemon and forcing to restart Apache/php-fpm 