### PR TITLE
Add verify_agent_config virtualenv support

### DIFF
--- a/providers/agent_python.rb
+++ b/providers/agent_python.rb
@@ -55,8 +55,9 @@ def generate_agent_config
 end
 
 def verify_agent_config
+  virtualenv = "#{new_resource.virtualenv}/bin/" if new_resource.virtualenv
   execute 'verify-python-agent' do
-    command "newrelic-admin validate-config #{new_resource.config_file}"
+    command "#{virtualenv}newrelic-admin validate-config #{new_resource.config_file}"
   end
 end
 


### PR DESCRIPTION
Upon specifying a `virtualenv` for `newrelic_agent_python`, `verify_agent_config` will fail to know where to look for `newrelic-admin`.  This PR fixes that.