### PR TITLE
Replace hardcoded ownership by actual app_user and app_group

### DIFF
--- a/providers/agent_java.rb
+++ b/providers/agent_java.rb
@@ -54,8 +54,8 @@ def agent_jar
 
   remote_file "#{new_resource.install_dir}/newrelic.jar" do
     source https_download
-    owner 'root'
-    group 'root'
+    owner new_resource.app_user
+    group new_resource.app_group
     mode 0664
     action :create
   end
@@ -65,8 +65,8 @@ def generate_agent_config
   template "#{new_resource.install_dir}/newrelic.yml" do
     cookbook new_resource.template_cookbook
     source new_resource.template_source
-    owner 'root'
-    group 'root'
+    owner new_resource.app_user
+    group new_resource.app_group
     mode 0644
     variables(
       :resource => new_resource


### PR DESCRIPTION
In the `agent_java.rb` provider, the `agent_jar` and `generate_agent_config` defs contained hardcoded ownerships for the root user.

Replaced this by `app_user` and `app_group`. Fixes #219 