### PR TITLE
fix markdown formatting on java agent section

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,6 +452,7 @@ newrelic_agent_java 'Install' do
   license '0000ffff0000ffff0000ffff0000ffff0000ffff'  
   install_dir '/opt/newrelic/java'
   app_name 'java_test_app'
+```
 
 ### `newrelic_agent_python`  
 This cookbook includes an LWRP for installing the newrelic python agent


### PR DESCRIPTION
Triple quotes were missing at the end of the snippet and
that broke the formatting of the sections below