### PR TITLE
Added support for proxy and custom tracing in java agent configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Make sure you run Chef >= 0.10.0.
 * `node['newrelic']['java_agent']['log_daily']` - Override other log rolling configuration and roll the logs daily
 * `node['newrelic']['java_agent']['agent_action']` - Agent action, defaults to :install
 * `node['newrelic']['java_agent']['execute_agent_action']` - Execute the agent action or not, defaults to true
+* `node['newrelic']['java_agent']['enable_custom_tracing']` - Configure New Relic to detect custom traces
 * `node['newrelic']['java_agent']['app_location']` - Application server's location, defaults to nil
 * `node['newrelic']['java_agent']['template']['cookbook']` - Sets cookbook for template, defaults to 'newrelic'
 * `node['newrelic']['java_agent']['template']['source']` - Sets source for template, defaults to 'agent/newrelic.yml.erb'

--- a/attributes/java_agent.rb
+++ b/attributes/java_agent.rb
@@ -15,6 +15,7 @@ default['newrelic']['java_agent']['log_limit_in_kbytes'] = 0
 default['newrelic']['java_agent']['log_daily'] = true
 default['newrelic']['java_agent']['agent_action'] = :install
 default['newrelic']['java_agent']['execute_agent_action'] = true
+default['newrelic']['java_agent']['enable_custom_tracing'] = false
 default['newrelic']['java_agent']['app_location'] = node['newrelic']['java_agent']['install_dir']
 default['newrelic']['java_agent']['template']['cookbook'] = 'newrelic'
 default['newrelic']['java_agent']['template']['source'] = 'agent/newrelic.yml.erb'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'dev@escapestudios.com'
 license 'MIT'
 description 'Installs/Configures New Relic'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '2.17.0'
+version '2.17.1'
 
 %w( debian ubuntu redhat centos fedora scientific amazon windows smartos oracle ).each do |os|
   supports os

--- a/recipes/java_agent.rb
+++ b/recipes/java_agent.rb
@@ -12,6 +12,7 @@ newrelic_agent_java 'Install' do
   app_location node['newrelic']['java_agent']['app_location'] unless node['newrelic']['java_agent']['app_location'].nil?
   template_cookbook node['newrelic']['java_agent']['template_cookbook'] unless node['newrelic']['java_agent']['template_cookbook'].nil?
   template_source node['newrelic']['java_agent']['template_source'] unless node['newrelic']['java_agent']['template_source'].nil?
+  enable_custom_tracing node['newrelic']['java_agent']['enable_custom_tracing'] unless node['newrelic']['java_agent']['enable_custom_tracing'].nil?
   enabled node['newrelic']['application_monitoring']['enabled'] unless node['newrelic']['application_monitoring']['enabled'].nil?
   app_name node['newrelic']['application_monitoring']['app_name'] unless node['newrelic']['application_monitoring']['app_name'].nil?
   high_security NewRelic.to_boolean(node['newrelic']['application_monitoring']['high_security']) unless node['newrelic']['application_monitoring']['high_security'].nil?

--- a/recipes/java_agent.rb
+++ b/recipes/java_agent.rb
@@ -27,6 +27,10 @@ newrelic_agent_java 'Install' do
   log_daily node['newrelic']['java_agent']['log_daily'] unless node['newrelic']['java_agent']['log_daily'].nil?
   daemon_ssl NewRelic.to_boolean(node['newrelic']['application_monitoring']['daemon']['ssl']) unless node['newrelic']['application_monitoring']['daemon']['ssl'].nil?
   daemon_proxy node['newrelic']['application_monitoring']['daemon']['proxy'] unless node['newrelic']['application_monitoring']['daemon']['proxy'].nil?
+  daemon_proxy_host node['newrelic']['application_monitoring']['daemon']['proxy_host'] unless node['newrelic']['application_monitoring']['daemon']['proxy_host'].nil?
+  daemon_proxy_port node['newrelic']['application_monitoring']['daemon']['proxy_port'] unless node['newrelic']['application_monitoring']['daemon']['proxy_port'].nil?
+  daemon_proxy_user node['newrelic']['application_monitoring']['daemon']['proxy_user'] unless node['newrelic']['application_monitoring']['daemon']['proxy_user'].nil?
+  daemon_proxy_password node['newrelic']['application_monitoring']['daemon']['proxy_password'] unless node['newrelic']['application_monitoring']['daemon']['proxy_password'].nil?
   capture_params node['newrelic']['application_monitoring']['capture_params'] unless node['newrelic']['application_monitoring']['capture_params'].nil?
   ignored_params node['newrelic']['application_monitoring']['ignored_params'] unless node['newrelic']['application_monitoring']['ignored_params'].nil?
   transaction_tracer_enable node['newrelic']['application_monitoring']['transaction_tracer']['enable'] unless node['newrelic']['application_monitoring']['transaction_tracer']['enable'].nil?

--- a/resources/agent_java.rb
+++ b/resources/agent_java.rb
@@ -38,6 +38,7 @@ attribute :daemon_proxy_user, :kind_of => String, :default => nil
 attribute :daemon_proxy_password, :kind_of => String, :default => nil
 attribute :capture_params, :kind_of => String, :default => nil
 attribute :ignored_params, :kind_of => String, :default => nil
+attribute :enable_custom_tracing, :kind_of => [TrueClass, FalseClass], :default => false
 attribute :transaction_tracer_enable, :kind_of => [TrueClass, FalseClass], :default => true
 attribute :transaction_tracer_threshold, :kind_of => String, :default => nil
 attribute :transaction_tracer_record_sql, :kind_of => String, :default => nil

--- a/templates/default/agent/newrelic.yml.erb
+++ b/templates/default/agent/newrelic.yml.erb
@@ -180,6 +180,10 @@ common: &default_settings
   ignored_params: <%= @resource.ignored_params %>
   <% end %>
 
+  # Configure New Relic to detect custom traces
+  # https://docs.newrelic.com/docs/agents/java-agent/custom-instrumentation/java-instrumentation-annotation
+  enable_custom_tracing: <%= @resource.enable_custom_tracing %>
+
   # Transaction tracer captures deep information about slow
   # transactions and sends this to the New Relic service once a
   # minute. Included in the transaction is the exact call sequence of


### PR DESCRIPTION
I coudn't ran the tests, seems that travis neither.

E, [2015-11-20T16:00:43.061528 #8144] ERROR -- : Actor crashed!
Faraday::Error: :gzip is not registered on Faraday::Response

The changes added support to enable custom tracing in the java agent and proxy configuration using host, port, username and password.